### PR TITLE
Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#
 
 Execution time is `O(n)` on input size. It can be I/O bound; you can control I/O and performance implications by the `io.Reader` you pass to `NewScanner`.
 
-In my local testing (Mac laptop), `uax29/words` processes around 5MM tokens per second of English wiki text.
+In my local testing (Mac laptop), `uax29/words` processes around 12MM tokens per second of English wiki text.
 
 ### Status
 

--- a/graphemes/scanner.go
+++ b/graphemes/scanner.go
@@ -66,12 +66,10 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		// Rules are usually of the form Cat1 × Cat2; "current" refers to the first category
 		// to the right of the ×, from which we look back or forward
 
-		// Decoding runes is a bit redundant, it happens in other places too
-		// We do it here for clarity and to pick up errors early
 		current, w := trie.lookup(data[pos:])
 
-		_, pw := utf8.DecodeLastRune(data[:pos])
-		last, _ := trie.lookup(data[pos-pw:])
+		_, lw := utf8.DecodeLastRune(data[:pos])
+		last, _ := trie.lookup(data[pos-lw:])
 
 		// https://unicode.org/reports/tr29/#GB3
 		if is(_LF, current) && is(_CR, last) {
@@ -126,7 +124,7 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#GB11
-		if is(_ExtendedPictographic, current) && is(_ZWJ, last) && previous(_ExtendedPictographic, data[:pos-pw]) {
+		if is(_ExtendedPictographic, current) && is(_ZWJ, last) && previous(_ExtendedPictographic, data[:pos-lw]) {
 			pos += w
 			continue
 		}

--- a/graphemes/seek.go
+++ b/graphemes/seek.go
@@ -11,11 +11,13 @@ func previous(categories uint16, data []byte) bool {
 		_, w := utf8.DecodeLastRune(data[:i])
 		i -= w
 
-		if is(_Ignore, data[i:]) {
+		lookup, _ := trie.lookup(data[i:])
+
+		if is(_Ignore, lookup) {
 			continue
 		}
 
-		if is(categories, data[i:]) {
+		if is(categories, lookup) {
 			return true
 		}
 

--- a/sentences/scanner.go
+++ b/sentences/scanner.go
@@ -68,13 +68,10 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		// Rules are usually of the form Cat1 × Cat2; "current" refers to the first category
 		// to the right of the ×, from which we look back or forward
 
-		// Decoding runes is a bit redundant, it happens in other places too
-		// We do it here for clarity and to pick up errors early
-
 		current, w := trie.lookup(data[pos:])
 
-		_, pw := utf8.DecodeLastRune(data[:pos])
-		last, _ := trie.lookup(data[pos-pw:])
+		_, lw := utf8.DecodeLastRune(data[:pos])
+		last, _ := trie.lookup(data[pos-lw:])
 
 		// https://unicode.org/reports/tr29/#SB3
 		if is(_LF, current) && is(_CR, last) {

--- a/sentences/seek.go
+++ b/sentences/seek.go
@@ -12,11 +12,13 @@ func previousIndex(categories uint16, data []byte) int {
 		_, w := utf8.DecodeLastRune(data[:i])
 		i -= w
 
-		if is(_Ignore, data[i:]) {
+		lookup, _ := trie.lookup(data[i:])
+
+		if is(_Ignore, lookup) {
 			continue
 		}
 
-		if is(categories, data[i:]) {
+		if is(categories, lookup) {
 			return i
 		}
 
@@ -38,14 +40,14 @@ func previous(categories uint16, data []byte) bool {
 func subsequent(categories uint16, data []byte) bool {
 	i := 0
 	for i < len(data) {
-		_, w := utf8.DecodeRune(data[i:])
+		lookup, w := trie.lookup(data[i:])
 
-		if is(_Ignore, data[i:]) {
+		if is(_Ignore, lookup) {
 			i += w
 			continue
 		}
 
-		if is(categories, data[i:]) {
+		if is(categories, lookup) {
 			return true
 		}
 

--- a/words/README.md
+++ b/words/README.md
@@ -35,4 +35,4 @@ We use the official [test suite](https://unicode.org/reports/tr41/tr41-26.html#T
 
 Execution time is `O(n)` on input size. It can be I/O bound; you can control I/O and performance implications by the `io.Reader` you pass to `NewScanner`.
 
-In my local testing (Mac laptop), `uax29/words` processes around 5MM tokens per second of English wiki text.
+In my local testing (Mac laptop), `uax29/words` processes around 12MM tokens per second of English wiki text.

--- a/words/scanner.go
+++ b/words/scanner.go
@@ -68,14 +68,11 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		// Rules are usually of the form Cat1 × Cat2; "current" refers to the first category
 		// to the right of the ×, from which we look back or forward
 
-		// Decoding runes is a bit redundant, it happens in other places too
-		// We do it here for clarity and to pick up errors early
-
 		current, w := trie.lookup(data[pos:])
 		next := pos + w
 
-		_, pw := utf8.DecodeLastRune(data[:pos])
-		last, _ := trie.lookup(data[pos-pw:])
+		_, lw := utf8.DecodeLastRune(data[:pos])
+		last, _ := trie.lookup(data[pos-lw:])
 
 		// https://unicode.org/reports/tr29/#WB3
 		if is(_LF, current) && is(_CR, last) {

--- a/words/scanner.go
+++ b/words/scanner.go
@@ -27,15 +27,9 @@ func NewScanner(r io.Reader) *bufio.Scanner {
 
 var trie = newWordsTrie(0)
 
-// is tests if the first rune of s is in categories
-func is(categories uint32, s []byte) bool {
-	lookup, _ := trie.lookup(s)
-	return is2(categories, lookup)
-}
-
-// is2 tests if the first rune of s is in categories
-func is2(categories, lookup uint32) bool {
-	return (lookup & categories) != 0
+// is tests if lookup intersects categories
+func is(categories, lookup uint32) bool {
+	return (categories & lookup) != 0
 }
 
 var _AHLetter = _ALetter | _HebrewLetter
@@ -48,21 +42,21 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		return 0, nil, nil
 	}
 
-	current := 0
+	pos := 0
 
 	for {
-		if current == len(data) && !atEOF {
+		if pos == len(data) && !atEOF {
 			// Request more data
 			return 0, nil, nil
 		}
 
-		sot := current == 0 // "start of text"
-		eof := len(data) == current
+		sot := pos == 0 // "start of text"
+		eof := len(data) == pos
 
 		// https://unicode.org/reports/tr29/#WB1
 		if sot && !eof {
-			_, w := utf8.DecodeRune(data[current:])
-			current += w
+			_, w := utf8.DecodeRune(data[pos:])
+			pos += w
 			continue
 		}
 
@@ -77,44 +71,43 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		// Decoding runes is a bit redundant, it happens in other places too
 		// We do it here for clarity and to pick up errors early
 
-		lookup, w := trie.lookup(data[current:])
+		current, w := trie.lookup(data[pos:])
+		next := pos + w
 
-		next := current + w
-
-		_, pw := utf8.DecodeLastRune(data[:current])
-		last := current - pw
+		_, pw := utf8.DecodeLastRune(data[:pos])
+		last, _ := trie.lookup(data[pos-pw:])
 
 		// https://unicode.org/reports/tr29/#WB3
-		if is2(_LF, lookup) && is(_CR, data[last:]) {
-			current += w
+		if is(_LF, current) && is(_CR, last) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB3a
-		if is(_CR|_LF|_Newline, data[last:]) {
+		if is(_CR|_LF|_Newline, last) {
 			break
 		}
 
 		// https://unicode.org/reports/tr29/#WB3b
-		if is2(_CR|_LF|_Newline, lookup) {
+		if is(_CR|_LF|_Newline, current) {
 			break
 		}
 
 		// https://unicode.org/reports/tr29/#WB3c
-		if is2(_ExtendedPictographic, lookup) && is(_ZWJ, data[last:]) {
-			current += w
+		if is(_ExtendedPictographic, current) && is(_ZWJ, last) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB3d
-		if is2(_WSegSpace, lookup) && is(_WSegSpace, data[last:]) {
-			current += w
+		if is(_WSegSpace, current) && is(_WSegSpace, last) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB4
-		if is2(_Extend|_Format|_ZWJ, lookup) {
-			current += w
+		if is(_Extend|_Format|_ZWJ, current) {
+			pos += w
 			continue
 		}
 
@@ -123,14 +116,14 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		// The previous/subsequent methods are shorthand for "seek a category but skip over Extend|Format|ZWJ on the way"
 
 		// https://unicode.org/reports/tr29/#WB5
-		if is2(_AHLetter, lookup) && previous(_AHLetter, data[:current]) {
-			current += w
+		if is(_AHLetter, current) && previous(_AHLetter, data[:pos]) {
+			pos += w
 
 			// Optimization: there's a likelihood of a run of AHLetter
-			for current < len(data) {
-				_, w := utf8.DecodeRune(data[current:])
-				if is(_AHLetter, data[current:]) {
-					current += w
+			for pos < len(data) {
+				lookup, w := trie.lookup(data[pos:])
+				if is(_AHLetter, lookup) {
+					pos += w
 					continue
 				}
 				break
@@ -140,50 +133,50 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB6
-		if is2(_MidLetter|_MidNumLetQ, lookup) && subsequent(_AHLetter, data[next:]) && previous(_AHLetter, data[:current]) {
-			current += w
+		if is(_MidLetter|_MidNumLetQ, current) && subsequent(_AHLetter, data[next:]) && previous(_AHLetter, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB7
-		if is2(_AHLetter, lookup) {
-			pi := previousIndex(_MidLetter|_MidNumLetQ, data[:current])
+		if is(_AHLetter, current) {
+			pi := previousIndex(_MidLetter|_MidNumLetQ, data[:pos])
 			if pi >= 0 && previous(_AHLetter, data[:pi]) {
-				current += w
+				pos += w
 				continue
 			}
 		}
 
 		// https://unicode.org/reports/tr29/#WB7a
-		if is2(_SingleQuote, lookup) && previous(_HebrewLetter, data[:current]) {
-			current += w
+		if is(_SingleQuote, current) && previous(_HebrewLetter, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB7b
-		if is2(_DoubleQuote, lookup) && subsequent(_HebrewLetter, data[next:]) && previous(_HebrewLetter, data[:current]) {
-			current += w
+		if is(_DoubleQuote, current) && subsequent(_HebrewLetter, data[next:]) && previous(_HebrewLetter, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB7c
-		if is2(_HebrewLetter, lookup) {
-			pi := previousIndex(_DoubleQuote, data[:current])
+		if is(_HebrewLetter, current) {
+			pi := previousIndex(_DoubleQuote, data[:pos])
 			if pi >= 0 && previous(_HebrewLetter, data[:pi]) {
-				current += w
+				pos += w
 				continue
 			}
 		}
 
 		// https://unicode.org/reports/tr29/#WB8
-		if is2(_Numeric, lookup) && previous(_Numeric, data[:current]) {
-			current += w
+		if is(_Numeric, current) && previous(_Numeric, data[:pos]) {
+			pos += w
 
 			// Optimization: there's a likelihood of a run of Numeric
-			for current < len(data) {
-				_, w := utf8.DecodeRune(data[current:])
-				if is(_Numeric, data[current:]) {
-					current += w
+			for pos < len(data) {
+				lookup, w := trie.lookup(data[pos:])
+				if is(_Numeric, lookup) {
+					pos += w
 					continue
 				}
 				break
@@ -193,41 +186,41 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB9
-		if is2(_Numeric, lookup) && previous(_AHLetter, data[:current]) {
-			current += w
+		if is(_Numeric, current) && previous(_AHLetter, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB10
-		if is2(_AHLetter, lookup) && previous(_Numeric, data[:current]) {
-			current += w
+		if is(_AHLetter, current) && previous(_Numeric, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB11
-		if is2(_Numeric, lookup) {
-			pi := previousIndex(_MidNum|_MidNumLetQ, data[:current])
+		if is(_Numeric, current) {
+			pi := previousIndex(_MidNum|_MidNumLetQ, data[:pos])
 			if pi >= 0 && previous(_Numeric, data[:pi]) {
-				current += w
+				pos += w
 				continue
 			}
 		}
 
 		// https://unicode.org/reports/tr29/#WB12
-		if is2(_MidNum|_MidNumLet|_SingleQuote, lookup) && subsequent(_Numeric, data[next:]) && previous(_Numeric, data[:current]) {
-			current += w
+		if is(_MidNum|_MidNumLet|_SingleQuote, current) && subsequent(_Numeric, data[next:]) && previous(_Numeric, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB13
-		if is2(_Katakana, lookup) && previous(_Katakana, data[:current]) {
-			current += w
+		if is(_Katakana, current) && previous(_Katakana, data[:pos]) {
+			pos += w
 
 			// Optimization: there's a likelihood of a run of Katakana
-			for current < len(data) {
-				_, w := utf8.DecodeRune(data[current:])
-				if is(_Katakana, data[current:]) {
-					current += w
+			for pos < len(data) {
+				lookup, w := trie.lookup(data[pos:])
+				if is(_Katakana, lookup) {
+					pos += w
 					continue
 				}
 				break
@@ -237,67 +230,77 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB13a
-		if is2(_ExtendNumLet, lookup) && previous(_AHLetter|_Numeric|_Katakana|_ExtendNumLet, data[:current]) {
-			current += w
+		if is(_ExtendNumLet, current) && previous(_AHLetter|_Numeric|_Katakana|_ExtendNumLet, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB13b
-		if is2(_AHLetter|_Numeric|_Katakana, lookup) && previous(_ExtendNumLet, data[:current]) {
-			current += w
+		if is(_AHLetter|_Numeric|_Katakana, current) && previous(_ExtendNumLet, data[:pos]) {
+			pos += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB15
-		if is2(_RegionalIndicator, lookup) {
+		if is(_RegionalIndicator, current) {
 			allRI := true
 
 			// Buffer comprised entirely of an odd number of RI, ignoring Extend|Format|ZWJ
-			i := current
+			i := pos
 			count := 0
 			for i > 0 {
 				_, w := utf8.DecodeLastRune(data[:i])
 				i -= w
-				if is(_Ignore, data[i:]) {
+
+				lookup, _ := trie.lookup(data[i:])
+
+				if is(_Ignore, lookup) {
 					continue
 				}
-				if !is(_RegionalIndicator, data[i:]) {
+
+				if !is(_RegionalIndicator, lookup) {
 					allRI = false
 					break
 				}
+
 				count++
 			}
 
 			if allRI {
 				odd := count > 0 && count%2 == 1
 				if odd {
-					current += w
+					pos += w
 					continue
 				}
 			}
 		}
 
 		// https://unicode.org/reports/tr29/#WB16
-		if is2(_RegionalIndicator, lookup) {
+		if is(_RegionalIndicator, current) {
 			odd := false
 			// Last n runes represent an odd number of RI, ignoring Extend|Format|ZWJ
-			i := current
+			i := pos
 			count := 0
 			for i > 0 {
 				_, w := utf8.DecodeLastRune(data[:i])
 				i -= w
-				if is(_Ignore, data[i:]) {
+
+				lookup, _ := trie.lookup(data[i:])
+
+				if is(_Ignore, lookup) {
 					continue
 				}
-				if !is(_RegionalIndicator, data[i:]) {
+
+				if !is(_RegionalIndicator, lookup) {
 					odd = count > 0 && count%2 == 1
 					break
 				}
+
 				count++
 			}
 
 			if odd {
-				current += w
+				pos += w
 				continue
 			}
 		}
@@ -307,5 +310,5 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		break
 	}
 
-	return current, data[:current], nil
+	return pos, data[:pos], nil
 }

--- a/words/scanner.go
+++ b/words/scanner.go
@@ -3,7 +3,6 @@ package words
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"unicode/utf8"
 )
@@ -31,6 +30,11 @@ var trie = newWordsTrie(0)
 // is tests if the first rune of s is in categories
 func is(categories uint32, s []byte) bool {
 	lookup, _ := trie.lookup(s)
+	return is2(categories, lookup)
+}
+
+// is2 tests if the first rune of s is in categories
+func is2(categories, lookup uint32) bool {
 	return (lookup & categories) != 0
 }
 
@@ -73,10 +77,7 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		// Decoding runes is a bit redundant, it happens in other places too
 		// We do it here for clarity and to pick up errors early
 
-		r, w := utf8.DecodeRune(data[current:])
-		if r == utf8.RuneError {
-			return 0, nil, fmt.Errorf("error decoding rune at byte 0x%x", data[current])
-		}
+		lookup, w := trie.lookup(data[current:])
 
 		next := current + w
 
@@ -84,7 +85,7 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		last := current - pw
 
 		// https://unicode.org/reports/tr29/#WB3
-		if is(_LF, data[current:]) && is(_CR, data[last:]) {
+		if is2(_LF, lookup) && is(_CR, data[last:]) {
 			current += w
 			continue
 		}
@@ -95,24 +96,24 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB3b
-		if is(_CR|_LF|_Newline, data[current:]) {
+		if is2(_CR|_LF|_Newline, lookup) {
 			break
 		}
 
 		// https://unicode.org/reports/tr29/#WB3c
-		if is(_ExtendedPictographic, data[current:]) && is(_ZWJ, data[last:]) {
+		if is2(_ExtendedPictographic, lookup) && is(_ZWJ, data[last:]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB3d
-		if is(_WSegSpace, data[current:]) && is(_WSegSpace, data[last:]) {
+		if is2(_WSegSpace, lookup) && is(_WSegSpace, data[last:]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB4
-		if is(_Extend|_Format|_ZWJ, data[current:]) {
+		if is2(_Extend|_Format|_ZWJ, lookup) {
 			current += w
 			continue
 		}
@@ -122,7 +123,7 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		// The previous/subsequent methods are shorthand for "seek a category but skip over Extend|Format|ZWJ on the way"
 
 		// https://unicode.org/reports/tr29/#WB5
-		if is(_AHLetter, data[current:]) && previous(_AHLetter, data[:current]) {
+		if is2(_AHLetter, lookup) && previous(_AHLetter, data[:current]) {
 			current += w
 
 			// Optimization: there's a likelihood of a run of AHLetter
@@ -139,13 +140,13 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB6
-		if is(_MidLetter|_MidNumLetQ, data[current:]) && subsequent(_AHLetter, data[next:]) && previous(_AHLetter, data[:current]) {
+		if is2(_MidLetter|_MidNumLetQ, lookup) && subsequent(_AHLetter, data[next:]) && previous(_AHLetter, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB7
-		if is(_AHLetter, data[current:]) {
+		if is2(_AHLetter, lookup) {
 			pi := previousIndex(_MidLetter|_MidNumLetQ, data[:current])
 			if pi >= 0 && previous(_AHLetter, data[:pi]) {
 				current += w
@@ -154,19 +155,19 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB7a
-		if is(_SingleQuote, data[current:]) && previous(_HebrewLetter, data[:current]) {
+		if is2(_SingleQuote, lookup) && previous(_HebrewLetter, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB7b
-		if is(_DoubleQuote, data[current:]) && subsequent(_HebrewLetter, data[next:]) && previous(_HebrewLetter, data[:current]) {
+		if is2(_DoubleQuote, lookup) && subsequent(_HebrewLetter, data[next:]) && previous(_HebrewLetter, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB7c
-		if is(_HebrewLetter, data[current:]) {
+		if is2(_HebrewLetter, lookup) {
 			pi := previousIndex(_DoubleQuote, data[:current])
 			if pi >= 0 && previous(_HebrewLetter, data[:pi]) {
 				current += w
@@ -175,7 +176,7 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB8
-		if is(_Numeric, data[current:]) && previous(_Numeric, data[:current]) {
+		if is2(_Numeric, lookup) && previous(_Numeric, data[:current]) {
 			current += w
 
 			// Optimization: there's a likelihood of a run of Numeric
@@ -192,19 +193,19 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB9
-		if is(_Numeric, data[current:]) && previous(_AHLetter, data[:current]) {
+		if is2(_Numeric, lookup) && previous(_AHLetter, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB10
-		if is(_AHLetter, data[current:]) && previous(_Numeric, data[:current]) {
+		if is2(_AHLetter, lookup) && previous(_Numeric, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB11
-		if is(_Numeric, data[current:]) {
+		if is2(_Numeric, lookup) {
 			pi := previousIndex(_MidNum|_MidNumLetQ, data[:current])
 			if pi >= 0 && previous(_Numeric, data[:pi]) {
 				current += w
@@ -213,13 +214,13 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB12
-		if is(_MidNum|_MidNumLet|_SingleQuote, data[current:]) && subsequent(_Numeric, data[next:]) && previous(_Numeric, data[:current]) {
+		if is2(_MidNum|_MidNumLet|_SingleQuote, lookup) && subsequent(_Numeric, data[next:]) && previous(_Numeric, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB13
-		if is(_Katakana, data[current:]) && previous(_Katakana, data[:current]) {
+		if is2(_Katakana, lookup) && previous(_Katakana, data[:current]) {
 			current += w
 
 			// Optimization: there's a likelihood of a run of Katakana
@@ -236,19 +237,19 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB13a
-		if is(_ExtendNumLet, data[current:]) && previous(_AHLetter|_Numeric|_Katakana|_ExtendNumLet, data[:current]) {
+		if is2(_ExtendNumLet, lookup) && previous(_AHLetter|_Numeric|_Katakana|_ExtendNumLet, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB13b
-		if is(_AHLetter|_Numeric|_Katakana, data[current:]) && previous(_ExtendNumLet, data[:current]) {
+		if is2(_AHLetter|_Numeric|_Katakana, lookup) && previous(_ExtendNumLet, data[:current]) {
 			current += w
 			continue
 		}
 
 		// https://unicode.org/reports/tr29/#WB15
-		if is(_RegionalIndicator, data[current:]) {
+		if is2(_RegionalIndicator, lookup) {
 			allRI := true
 
 			// Buffer comprised entirely of an odd number of RI, ignoring Extend|Format|ZWJ
@@ -277,7 +278,7 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB16
-		if is(_RegionalIndicator, data[current:]) {
+		if is2(_RegionalIndicator, lookup) {
 			odd := false
 			// Last n runes represent an odd number of RI, ignoring Extend|Format|ZWJ
 			i := current

--- a/words/seek.go
+++ b/words/seek.go
@@ -12,11 +12,13 @@ func previousIndex(categories uint32, data []byte) int {
 		_, w := utf8.DecodeLastRune(data[:i])
 		i -= w
 
-		if is(_Ignore, data[i:]) {
+		lookup, _ := trie.lookup(data[i:])
+
+		if is(_Ignore, lookup) {
 			continue
 		}
 
-		if is(categories, data[i:]) {
+		if is(categories, lookup) {
 			return i
 		}
 
@@ -38,14 +40,14 @@ func previous(categories uint32, data []byte) bool {
 func subsequent(categories uint32, data []byte) bool {
 	i := 0
 	for i < len(data) {
-		_, w := utf8.DecodeRune(data[i:])
+		lookup, w := trie.lookup(data[i:])
 
-		if is(_Ignore, data[i:]) {
+		if is(_Ignore, lookup) {
 			i += w
 			continue
 		}
 
-		if is(categories, data[i:]) {
+		if is(categories, lookup) {
 			return true
 		}
 


### PR DESCRIPTION
An obvious perf improvement in retrospect: only lookup categories for current rune once per loop iteration. The previous `is` method did a lookup each time.

Improvement looks to be a lot, nearly double the throughput for graphemes & words, maybe 50% for sentences.