### PR TITLE
Start, End and AlphaNumeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ We use the official [test suites](https://unicode.org/reports/tr41/tr41-26.html#
 [blevesearch/segment](https://github.com/blevesearch/segment)
 
 [rivo/uniseg](https://github.com/rivo/uniseg)
+
+### Other language implementations
+
+[JavaScript](https://github.com/tc39/proposal-intl-segmenter)
+
+[Rust](https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/trait.UnicodeSegmentation.html)
+
+[Java](https://lucene.apache.org/core/3_5_0/api/core/org/apache/lucene/analysis/standard/StandardTokenizerImpl.html)
+
+[Python](https://uniseg-python.readthedocs.io/en/latest/)

--- a/iterators/filter/filter.go
+++ b/iterators/filter/filter.go
@@ -1,3 +1,8 @@
+// Package filter provides methods for filtering via Scanners and Segmenters. A filter is
+// defined as a func(text []byte) bool -- given a string, what is true about it?
+//
+// A filter can contain arbitrary logic. A common use of a filter is to determine
+// what Unicode categories a string belongs to.
 package filter
 
 import (
@@ -5,48 +10,61 @@ import (
 	"unicode/utf8"
 
 	"github.com/clipperhouse/uax29/iterators/util"
+	"golang.org/x/text/unicode/rangetable"
 )
 
 type Func func([]byte) bool
 type Predicate = Func // for backwards compat, this was renamed
 
-// Contains returns a filter (predicate) indicating that a segment (token) contains one
-// or more runes that are in one or more of the given ranges. Examples of ranges
-// are things like unicode.Letter, unicode.Arabic, or unicode.Lower,
-// allowing testing for a wide variety of character or script types.
-//
-// Intended for passing to segmenter.Filter or scanner.Filter.
-//
-// If the given token is empty, or no ranges are given, it will return false.
-func Contains(ranges ...*unicode.RangeTable) Func {
-	return func(token []byte) bool {
-		return util.Contains(token, ranges...)
-	}
-}
-
-// Entirely returns a filter (predicate) indicating that a segment (token)
-// consists entirely of runes that are in one or more of the given ranges.
+// Contains returns a filter indicating that a token contains one
+// or more runes that are in one or more of the given ranges.
 // Examples of ranges are things like unicode.Letter, unicode.Arabic,
-// or unicode.Lower, allowing testing for a wide variety of character
+// or unicode.Lower, allowing testing for a variety of character
 // or script types.
-//
-// Intended for passing to segmenter.Filter or scanner.Filter.
-//
-// If the given token is empty, or no ranges are given, it will return false.
-func Entirely(ranges ...*unicode.RangeTable) Func {
+func Contains(ranges ...*unicode.RangeTable) Func {
+	merged := rangetable.Merge(ranges...)
 	return func(token []byte) bool {
-		return util.Entirely(token, ranges...)
+		return util.Contains(token, merged)
 	}
 }
 
-// Wordlike is a filter which returns only tokens (segments) that are “words”
-// in the common sense, excluding tokens that are whitespace or punctuation.
-// It includes any token that contains a Letter, Number, or Symbol, as defined
-// by Unicode. To use it, call Filter(Wordlike) on a Segmenter or Scanner.
+// Entirely returns a filter indicating that a token consists
+// entirely of runes that are in one or more of the given ranges.
+// Examples of ranges are things like unicode.Letter, unicode.Arabic,
+// or unicode.Lower, allowing testing for a variety of character
+// or script types.
+func Entirely(ranges ...*unicode.RangeTable) Func {
+	merged := rangetable.Merge(ranges...)
+	return func(token []byte) bool {
+		return util.Entirely(token, merged)
+	}
+}
+
+// AlphaNumeric is a filter which returns only tokens
+// that contain a Letter or Number, as defined by Unicode.
+var AlphaNumeric Func = func(token []byte) bool {
+	pos := 0
+	for pos < len(token) {
+		r, w := utf8.DecodeRune(token[pos:])
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			// we use these methods instead of unicode.In for
+			// performance; these methods have ASCII fast paths
+			return true
+		}
+		pos += w
+	}
+
+	return false
+}
+
+// Wordlike is a filter which returns only tokens that contain
+// a Letter, Number, or Symbol, as defined by Unicode.
 var Wordlike Func = func(token []byte) bool {
 	pos := 0
 	for pos < len(token) {
 		r, w := utf8.DecodeRune(token[pos:])
+		// we use these methods instead of unicode.In for
+		// performance; these methods have ASCII fast paths
 		if unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsSymbol(r) {
 			return true
 		}

--- a/iterators/filter/filter.go
+++ b/iterators/filter/filter.go
@@ -14,6 +14,8 @@ import (
 )
 
 type Func func([]byte) bool
+
+// Deprecated: renamed to Func
 type Predicate = Func // for backwards compat, this was renamed
 
 // Contains returns a filter indicating that a token contains one

--- a/iterators/scanner.go
+++ b/iterators/scanner.go
@@ -49,8 +49,8 @@ func (sc *Scanner) Err() error {
 
 // Filter applies one or more filters (predicates) to all tokens (segments), only returning those
 // where all predicates evaluate true. Filters are applied after Transformers.
-func (sc *Scanner) Filter(predicates ...filter.Func) {
-	sc.predicates = predicates
+func (sc *Scanner) Filter(filters ...filter.Func) {
+	sc.predicates = filters
 }
 
 var ErrorScanCalled = errors.New("cannot call Transform after Scan has been called")

--- a/iterators/scanner.go
+++ b/iterators/scanner.go
@@ -13,7 +13,7 @@ type s = *bufio.Scanner
 
 type Scanner struct {
 	s
-	predicates []filter.Func
+	filters []filter.Func
 
 	r     io.Reader // gotta keep references to these for Transform, sigh
 	split bufio.SplitFunc
@@ -47,10 +47,10 @@ func (sc *Scanner) Err() error {
 	return sc.s.Err()
 }
 
-// Filter applies one or more filters (predicates) to all tokens (segments), only returning those
-// where all predicates evaluate true. Filters are applied after Transformers.
+// Filter applies one or more filters (predicates) to all tokens, only returning those
+// where all filters evaluate true. Filters are applied after Transformers.
 func (sc *Scanner) Filter(filters ...filter.Func) {
-	sc.predicates = filters
+	sc.filters = filters
 }
 
 var ErrorScanCalled = errors.New("cannot call Transform after Scan has been called")
@@ -90,7 +90,7 @@ func (sc *Scanner) Scan() bool {
 
 scan:
 	for sc.s.Scan() {
-		for _, f := range sc.predicates {
+		for _, f := range sc.filters {
 			if !f(sc.Bytes()) {
 				continue scan
 			}

--- a/iterators/segmenter.go
+++ b/iterators/segmenter.go
@@ -40,7 +40,7 @@ func (seg *Segmenter) SetText(data []byte) {
 }
 
 // Filter applies one or more filters (predicates) to all tokens, returning only those
-// where all predicates evaluate true. Calling Filter will overwrite previous filters, so call it
+// where all filters evaluate true. Calling Filter will overwrite previous filters, so call it
 // once (it's variadic, you can add multiple).
 func (seg *Segmenter) Filter(filters ...filter.Func) {
 	seg.filters = filters
@@ -135,9 +135,6 @@ func (seg *Segmenter) Start() int {
 // will save you some code. The downside is that it allocates, and can do so
 // unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
 // memory usage.
-//
-// The predicates parameter is optional; when predicates is specified, All will
-// only return tokens (segments) for which all predicates evaluate to true.
 func All(src []byte, dest *[][]byte, split bufio.SplitFunc) error {
 	for pos := 0; pos < len(src); {
 		advance, token, err := split(src[pos:], true)

--- a/iterators/segmenter.go
+++ b/iterators/segmenter.go
@@ -19,6 +19,7 @@ type Segmenter struct {
 	data        []byte
 	token       []byte
 	start       int
+	pos         int
 	err         error
 }
 
@@ -35,7 +36,7 @@ func NewSegmenter(split bufio.SplitFunc) *Segmenter {
 func (seg *Segmenter) SetText(data []byte) {
 	seg.data = data
 	seg.token = nil
-	seg.start = 0
+	seg.pos = 0
 	seg.err = nil
 }
 
@@ -59,9 +60,11 @@ var ErrAdvanceTooFar = errors.New("SplitFunc advanced beyond the end of the data
 // are no remaining segments, or an error occurred.
 func (seg *Segmenter) Next() bool {
 next:
-	for seg.start < len(seg.data) {
-		advance, token, err := seg.split(seg.data[seg.start:], true)
-		seg.start += advance
+	for seg.pos < len(seg.data) {
+		seg.start = seg.pos
+
+		advance, token, err := seg.split(seg.data[seg.pos:], true)
+		seg.pos += advance
 		seg.token = token
 		seg.err = err
 
@@ -74,7 +77,7 @@ next:
 			seg.err = ErrAdvanceNegative
 			return false
 		}
-		if seg.start > len(seg.data) {
+		if seg.pos > len(seg.data) {
 			seg.err = ErrAdvanceTooFar
 			return false
 		}

--- a/iterators/segmenter.go
+++ b/iterators/segmenter.go
@@ -42,23 +42,8 @@ func (seg *Segmenter) SetText(data []byte) {
 // Filter applies one or more filters (predicates) to all tokens, returning only those
 // where all filters evaluate true. Calling Filter will overwrite previous filters, so call it
 // once (it's variadic, you can add multiple).
-func (seg *Segmenter) Filter(filters ...filter.Func) {
-	if len(filters) == 0 {
-		seg.filter = nil
-	}
-	if len(filters) == 1 {
-		seg.filter = filters[0]
-	}
-
-	// merge into a single func
-	seg.filter = func(token []byte) bool {
-		for _, f := range filters {
-			if !f(token) {
-				return false
-			}
-		}
-		return true
-	}
+func (seg *Segmenter) Filter(filters filter.Func) {
+	seg.filter = filters
 }
 
 // Transform applies one or more transforms to all tokens. Calling Transform will overwrite

--- a/iterators/segmenter_test.go
+++ b/iterators/segmenter_test.go
@@ -87,42 +87,20 @@ var endsWithW = func(token []byte) bool {
 func TestSegmenterFilterIsApplied(t *testing.T) {
 	text := "Hello, 世界, how are you? Nice dog aha! 👍🐶"
 
-	{
-		seg := iterators.NewSegmenter(bufio.ScanWords)
-		seg.SetText([]byte(text))
-		seg.Filter(startsWithH)
+	seg := iterators.NewSegmenter(bufio.ScanWords)
+	seg.SetText([]byte(text))
+	seg.Filter(startsWithH)
 
-		count := 0
-		for seg.Next() {
-			if !startsWithH(seg.Bytes()) {
-				t.Fatal("segmenter filter was not applied")
-			}
-			count++
+	count := 0
+	for seg.Next() {
+		if !startsWithH(seg.Bytes()) {
+			t.Fatal("segmenter filter was not applied")
 		}
-
-		if count != 2 {
-			t.Fatalf("segmenter filter should have found 2 results, got %d", count)
-		}
+		count++
 	}
 
-	{
-		// variadic
-		seg := iterators.NewSegmenter(bufio.ScanWords)
-		seg.SetText([]byte(text))
-		seg.Filter(startsWithH, endsWithW)
-
-		count := 0
-		for seg.Next() {
-			if !(startsWithH(seg.Bytes()) && endsWithW(seg.Bytes())) {
-				t.Fatal("variadic segmenter filter was not applied")
-			}
-			count++
-		}
-
-		if count != 1 {
-			t.Fatalf("variadic segmenter filter should have found 1 result, got %d", count)
-		}
-
+	if count != 2 {
+		t.Fatalf("segmenter filter should have found 2 results, got %d", count)
 	}
 }
 

--- a/iterators/segmenter_test.go
+++ b/iterators/segmenter_test.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"math/rand"
+	"reflect"
 	"testing"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/clipperhouse/uax29/iterators"
+	"github.com/clipperhouse/uax29/iterators/filter"
 	"github.com/clipperhouse/uax29/iterators/transformer"
 	"github.com/clipperhouse/uax29/words"
 )
@@ -131,4 +133,66 @@ func TestSegmenterTransformIsApplied(t *testing.T) {
 			t.Fatalf("transforms of lower case or diacritics were not applied, expected %q, got %q", expected, got)
 		}
 	}
+}
+
+func TestSegmenterStart(t *testing.T) {
+	text := []byte("Hello world")
+
+	{
+		seg := words.NewSegmenter(text)
+		expected := []int{0, 5, 6}
+		var got []int
+		for seg.Next() {
+			got = append(got, seg.Start())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatal("starts failed")
+		}
+	}
+
+	{
+		seg := words.NewSegmenter(text)
+		seg.Filter(filter.AlphaNumeric)
+		expected := []int{0, 6}
+		var got []int
+		for seg.Next() {
+			got = append(got, seg.Start())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatal("filtered starts failed")
+		}
+	}
+}
+
+func TestSegmenterEnd(t *testing.T) {
+	text := []byte("Hello world")
+
+	{
+		seg := words.NewSegmenter(text)
+
+		expected := []int{5, 6, len(text)}
+		var got []int
+		for seg.Next() {
+			got = append(got, seg.End())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatal("ends failed")
+		}
+	}
+
+	{
+		seg := words.NewSegmenter(text)
+		seg.Filter(filter.AlphaNumeric)
+
+		expected := []int{5, len(text)}
+		var got []int
+		for seg.Next() {
+			got = append(got, seg.End())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Log(got)
+			t.Fatal("filtered ends failed")
+		}
+	}
+
 }

--- a/iterators/segmenter_test.go
+++ b/iterators/segmenter_test.go
@@ -146,6 +146,7 @@ func TestSegmenterStart(t *testing.T) {
 			got = append(got, seg.Start())
 		}
 		if !reflect.DeepEqual(got, expected) {
+			t.Log(got)
 			t.Fatal("starts failed")
 		}
 	}
@@ -159,6 +160,7 @@ func TestSegmenterStart(t *testing.T) {
 			got = append(got, seg.Start())
 		}
 		if !reflect.DeepEqual(got, expected) {
+			t.Log(got)
 			t.Fatal("filtered starts failed")
 		}
 	}
@@ -176,6 +178,7 @@ func TestSegmenterEnd(t *testing.T) {
 			got = append(got, seg.End())
 		}
 		if !reflect.DeepEqual(got, expected) {
+			t.Log(got)
 			t.Fatal("ends failed")
 		}
 	}

--- a/iterators/util/util.go
+++ b/iterators/util/util.go
@@ -8,15 +8,15 @@ import (
 // Contains indicates whether the token contains any runes that are in
 // one or more of the given ranges. If the token is empty, or no ranges
 // are given, it will return false.
-func Contains(token []byte, ranges ...*unicode.RangeTable) bool {
-	if len(token) == 0 || len(ranges) == 0 {
+func Contains(token []byte, rt *unicode.RangeTable) bool {
+	if len(token) == 0 {
 		return false
 	}
 
 	pos := 0
 	for pos < len(token) {
 		r, w := utf8.DecodeRune(token[pos:])
-		if unicode.In(r, ranges...) {
+		if unicode.Is(rt, r) {
 			return true
 		}
 		pos += w
@@ -28,15 +28,15 @@ func Contains(token []byte, ranges ...*unicode.RangeTable) bool {
 // Entirely indicates whether the token consists entirely of runes
 // that are in one or more of the given ranges. If the token is empty,
 // or no ranges are given, it will return false.
-func Entirely(token []byte, ranges ...*unicode.RangeTable) bool {
-	if len(token) == 0 || len(ranges) == 0 {
+func Entirely(token []byte, rt *unicode.RangeTable) bool {
+	if len(token) == 0 {
 		return false
 	}
 
 	pos := 0
 	for pos < len(token) {
 		r, w := utf8.DecodeRune(token[pos:])
-		if !unicode.In(r, ranges...) {
+		if !unicode.Is(rt, r) {
 			return false
 		}
 		pos += w

--- a/iterators/util/util_test.go
+++ b/iterators/util/util_test.go
@@ -5,6 +5,7 @@ import (
 	"unicode"
 
 	"github.com/clipperhouse/uax29/iterators/util"
+	"golang.org/x/text/unicode/rangetable"
 )
 
 func TestContains(t *testing.T) {
@@ -21,8 +22,10 @@ func TestContains(t *testing.T) {
 		{"世界", true},
 	}
 
+	ranges := rangetable.Merge(unicode.Latin, unicode.Ideographic)
+
 	for _, test := range tests {
-		got := util.Contains([]byte(test.input), unicode.Latin, unicode.Ideographic)
+		got := util.Contains([]byte(test.input), ranges)
 
 		if got != test.expected {
 			t.Error(test.expected)

--- a/words/segmenter_test.go
+++ b/words/segmenter_test.go
@@ -118,6 +118,15 @@ func TestSegmenterInvalidUTF8(t *testing.T) {
 	}
 }
 
+func TestSegmenterStart(t *testing.T) {
+	text := []byte("Hello world")
+	seg := words.NewSegmenter(text)
+	//seg.Filter(filter.AlphaNumeric)
+	for seg.Next() {
+		t.Log(seg.Start())
+	}
+}
+
 func BenchmarkSegmenter(b *testing.B) {
 	file, err := ioutil.ReadFile("testdata/sample.txt")
 

--- a/words/segmenter_test.go
+++ b/words/segmenter_test.go
@@ -118,15 +118,6 @@ func TestSegmenterInvalidUTF8(t *testing.T) {
 	}
 }
 
-func TestSegmenterStart(t *testing.T) {
-	text := []byte("Hello world")
-	seg := words.NewSegmenter(text)
-	//seg.Filter(filter.AlphaNumeric)
-	for seg.Next() {
-		t.Log(seg.Start())
-	}
-}
-
 func BenchmarkSegmenter(b *testing.B) {
 	file, err := ioutil.ReadFile("testdata/sample.txt")
 

--- a/words/segmenter_test.go
+++ b/words/segmenter_test.go
@@ -128,7 +128,7 @@ func BenchmarkSegmenter(b *testing.B) {
 	b.ResetTimer()
 	b.SetBytes(int64(len(file)))
 	seg := words.NewSegmenter(file)
-	seg.Filter(filter.Wordlike)
+	seg.Filter(filter.AlphaNumeric)
 
 	for i := 0; i < b.N; i++ {
 		seg.SetText(file)


### PR DESCRIPTION
Add new `segmenter.Start()` and `.End()` methods to indicate position of token in the original text.

New `filter.AlphaNumeric`, perhaps more useful than `Wordlike`.

Perf improvement (likely) by merging range tables in `segmenter.Filter` call.

Breaking change: `util.Contains/Entirely` are no longer variadic, which saves an allocation, and they're not really a user API.