### PR TITLE
More fixing of subsequent & scanner

### DIFF
--- a/graphemes/splitfunc.go
+++ b/graphemes/splitfunc.go
@@ -22,8 +22,17 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 
 	// https://unicode.org/reports/tr29/#GB1
 	{
-		// start of text always advances
+		// Start of text always advances
 		current, w = trie.lookup(data[pos:])
+		if w == 0 {
+			if !atEOF {
+				// Rune extends past current data, request more
+				return 0, nil, nil
+			}
+			pos = len(data)
+			return pos, data[:pos], nil
+		}
+
 		pos += w
 	}
 

--- a/iterators/scanner.go
+++ b/iterators/scanner.go
@@ -73,7 +73,6 @@ func (sc *Scanner) Scan() bool {
 		return false
 	}
 
-scan:
 	for sc.s.Scan() {
 		sc.token = sc.s.Bytes()
 
@@ -85,7 +84,7 @@ scan:
 		}
 
 		if sc.filter != nil && !sc.filter(sc.Bytes()) {
-			continue scan
+			continue
 		}
 
 		return true

--- a/iterators/scanner.go
+++ b/iterators/scanner.go
@@ -2,7 +2,6 @@ package iterators
 
 import (
 	"bufio"
-	"errors"
 	"io"
 
 	"github.com/clipperhouse/uax29/iterators/filter"
@@ -56,8 +55,6 @@ func (sc *Scanner) Err() error {
 func (sc *Scanner) Filter(filter filter.Func) {
 	sc.filter = filter
 }
-
-var ErrorScanCalled = errors.New("cannot call Transform after Scan has been called")
 
 // Transform applies one or more transformers to all tokens, in order. Calling Transform overwrites
 // previous transformers, so call it once (it's variadic, you can add multiple). Transformers are

--- a/iterators/segmenter_test.go
+++ b/iterators/segmenter_test.go
@@ -3,27 +3,30 @@ package iterators_test
 import (
 	"bufio"
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"reflect"
 	"testing"
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/clipperhouse/uax29/graphemes"
 	"github.com/clipperhouse/uax29/iterators"
 	"github.com/clipperhouse/uax29/iterators/filter"
 	"github.com/clipperhouse/uax29/iterators/transformer"
+	"github.com/clipperhouse/uax29/phrases"
+	"github.com/clipperhouse/uax29/sentences"
 	"github.com/clipperhouse/uax29/words"
 )
 
 func getRandomBytes() []byte {
-	b := make([]byte, 5000)
+	b := make([]byte, 50000)
 	rand.Read(b)
 
 	return b
 }
 
 func TestSegmenterSameAsScanner(t *testing.T) {
-	splits := []bufio.SplitFunc{words.SplitFunc, bufio.ScanWords}
+	splits := []bufio.SplitFunc{words.SplitFunc, sentences.SplitFunc, graphemes.SplitFunc, phrases.SplitFunc}
 	for _, split := range splits {
 		for i := 0; i < 100; i++ {
 			text := getRandomBytes()
@@ -36,7 +39,12 @@ func TestSegmenterSameAsScanner(t *testing.T) {
 
 			for seg.Next() && sc.Scan() {
 				if !bytes.Equal(seg.Bytes(), sc.Bytes()) {
-					t.Fatal("Scanner and Segmenter should give identical results")
+
+					t.Fatalf(`
+					Scanner and Segmenter should give identical results
+					Scanner:   %q
+					Segmenter: %q
+					`, sc.Bytes(), seg.Bytes())
 				}
 			}
 			if seg.Err() != nil {

--- a/phrases/seek.go
+++ b/phrases/seek.go
@@ -39,12 +39,17 @@ func previous(properties property, data []byte) bool {
 
 // subsequent looks ahead in the buffer until it hits a rune in properties,
 // ignoring runes with the _Ignore property per WB4
-func subsequent(properties property, data []byte) bool {
+func subsequent(properties property, data []byte, atEOF bool) (found bool, more bool) {
 	i := 0
 	for i < len(data) {
 		lookup, w := trie.lookup(data[i:])
 		if w == 0 {
-			break
+			if atEOF {
+				// Nothing more to evaluate
+				return false, false
+			}
+			// More to evaluate
+			return false, true
 		}
 
 		if lookup.is(_Ignore) {
@@ -53,12 +58,18 @@ func subsequent(properties property, data []byte) bool {
 		}
 
 		if lookup.is(properties) {
-			return true
+			// Found it
+			return true, false
 		}
 
 		// If we get this far, it's not there
-		break
+		return false, false
 	}
 
-	return false
+	if atEOF {
+		// Nothing more to evaluate
+		return false, false
+	}
+	// More to evaluate
+	return false, true
 }

--- a/sentences/seek.go
+++ b/sentences/seek.go
@@ -39,9 +39,6 @@ func previous(properties property, data []byte) bool {
 // subsequent looks ahead in the buffer until it hits a rune in properties,
 // ignoring runes in the _Ignore property per SB5
 func subsequent(properties property, data []byte, atEOF bool) (found bool, requestMore bool) {
-	if len(data) == 0 {
-	}
-
 	i := 0
 	for i < len(data) {
 		lookup, w := trie.lookup(data[i:])

--- a/sentences/splitfunc.go
+++ b/sentences/splitfunc.go
@@ -31,16 +31,15 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 
 	// https://unicode.org/reports/tr29/#SB1
 	{
-		// start of text always advances
+		// Start of text always advances
 		current, w = trie.lookup(data[pos:])
 		if w == 0 {
-			if atEOF {
-				// Just return the bytes, we can't do anything with them
-				pos = len(data)
-				return pos, data[:pos], nil
+			if !atEOF {
+				// Rune extends past current data, request more
+				return 0, nil, nil
 			}
-			// Rune extends past current data, request more
-			return 0, nil, nil
+			pos = len(data)
+			return pos, data[:pos], nil
 		}
 
 		pos += w

--- a/words/bleve_compat.go
+++ b/words/bleve_compat.go
@@ -47,7 +47,8 @@ func BleveNumeric(token []byte) bool {
 		// Optimization: determine if WB12 can possibly apply
 		maybeWB12 := last.is(_Numeric|_Ignore) && current.is(_MidNum|_MidNumLetQ)
 		if maybeWB12 {
-			if subsequent(_Numeric, token[pos+w:]) && previous(_Numeric, token[:pos]) {
+			found, _ := subsequent(_Numeric, token[pos+w:], true)
+			if found && previous(_Numeric, token[:pos]) {
 				pos += w
 				continue
 			}

--- a/words/seek.go
+++ b/words/seek.go
@@ -39,12 +39,17 @@ func previous(properties property, data []byte) bool {
 
 // subsequent looks ahead in the buffer until it hits a rune in properties,
 // ignoring runes with the _Ignore property per WB4
-func subsequent(properties property, data []byte) bool {
+func subsequent(properties property, data []byte, atEOF bool) (found bool, more bool) {
 	i := 0
 	for i < len(data) {
 		lookup, w := trie.lookup(data[i:])
 		if w == 0 {
-			break
+			if atEOF {
+				// Nothing more to evaluate
+				return false, false
+			}
+			// More to evaluate
+			return false, true
 		}
 
 		if lookup.is(_Ignore) {
@@ -53,12 +58,18 @@ func subsequent(properties property, data []byte) bool {
 		}
 
 		if lookup.is(properties) {
-			return true
+			// Found it
+			return true, false
 		}
 
 		// If we get this far, it's not there
-		break
+		return false, false
 	}
 
-	return false
+	if atEOF {
+		// Nothing more to evaluate
+		return false, false
+	}
+	// More to evaluate
+	return false, true
 }

--- a/words/splitfunc.go
+++ b/words/splitfunc.go
@@ -29,8 +29,17 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 
 	// https://unicode.org/reports/tr29/#WB1
 	{
-		// start of text always advances
+		// Start of text always advances
 		current, w = trie.lookup(data[pos:])
+		if w == 0 {
+			if !atEOF {
+				// Rune extends past current data, request more
+				return 0, nil, nil
+			}
+			pos = len(data)
+			return pos, data[:pos], nil
+		}
+
 		pos += w
 	}
 
@@ -113,9 +122,18 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB6
-		if current.is(_MidLetter|_MidNumLetQ) && lastExIgnore.is(_AHLetter) && subsequent(_AHLetter, data[pos+w:]) {
-			pos += w
-			continue
+		if current.is(_MidLetter|_MidNumLetQ) && lastExIgnore.is(_AHLetter) {
+			found, more := subsequent(_AHLetter, data[pos+w:], atEOF)
+
+			if more {
+				// Token extends past current data, request more
+				return 0, nil, nil
+			}
+
+			if found {
+				pos += w
+				continue
+			}
 		}
 
 		// https://unicode.org/reports/tr29/#WB7
@@ -131,9 +149,18 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB7b
-		if current.is(_DoubleQuote) && lastExIgnore.is(_HebrewLetter|_Ignore) && subsequent(_HebrewLetter, data[pos+w:]) {
-			pos += w
-			continue
+		if current.is(_DoubleQuote) && lastExIgnore.is(_HebrewLetter|_Ignore) {
+			found, more := subsequent(_HebrewLetter, data[pos+w:], atEOF)
+
+			if more {
+				// Token extends past current data, request more
+				return 0, nil, nil
+			}
+
+			if found {
+				pos += w
+				continue
+			}
 		}
 
 		// https://unicode.org/reports/tr29/#WB7c
@@ -157,9 +184,18 @@ func SplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		}
 
 		// https://unicode.org/reports/tr29/#WB12
-		if current.is(_MidNum|_MidNumLetQ) && lastExIgnore.is(_Numeric) && subsequent(_Numeric, data[pos+w:]) {
-			pos += w
-			continue
+		if current.is(_MidNum|_MidNumLetQ) && lastExIgnore.is(_Numeric) {
+			found, more := subsequent(_Numeric, data[pos+w:], atEOF)
+
+			if more {
+				// Token extends past current data, request more
+				return 0, nil, nil
+			}
+
+			if found {
+				pos += w
+				continue
+			}
 		}
 
 		// https://unicode.org/reports/tr29/#WB13


### PR DESCRIPTION
`subsequent` had problems where the `Scanner` (streaming) and `Segmenter` (static data) gave different results in a flaky way.

Only discovered by pushing a lot of random data. I hadn’t seen it until recently, at least partially (I believe) because the test data fit within the default `Scanner`’s default max buffer of 8KB. Only when exceeding 8KB could I get a repro with some frequency.

`subsequent` was not aware that it might be hitting the end of a buffer, it just knew that it was at the end of the static data it was passed. It now sends a signal back to request more data, upon reaching the end of the passed data.

In the real world, I believe this bug would only be triggered for tokens (word, sentence, etc) exceeding 4KB, which should be rare in natural language.