### PR TITLE
Fix race condition in transform.Lower & others

### DIFF
--- a/graphemes/scanner_test.go
+++ b/graphemes/scanner_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestScannerUnicode(t *testing.T) {
+	t.Parallel()
+
 	// From the Unicode test suite; see the gen/ folder.
 	var passed, failed int
 	for _, test := range unicodeTests {
@@ -46,6 +48,8 @@ func TestScannerUnicode(t *testing.T) {
 // TestScannerRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestScannerRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2_000
 
 	for i := 0; i < runs; i++ {
@@ -69,6 +73,8 @@ func TestScannerRoundtrip(t *testing.T) {
 }
 
 func TestInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
@@ -107,6 +113,8 @@ func TestInvalidUTF8(t *testing.T) {
 }
 
 func TestNeverZeroAtEOF(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return advance = 0 when atEOF. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 
@@ -124,6 +132,8 @@ func TestNeverZeroAtEOF(t *testing.T) {
 }
 
 func TestNeverErr(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return an error. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 

--- a/graphemes/segmenter_test.go
+++ b/graphemes/segmenter_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestSegmenterUnicode(t *testing.T) {
+	t.Parallel()
+
 	// From the Unicode test suite; see the gen/ folder.
 	var passed, failed int
 	for _, test := range unicodeTests {
@@ -52,6 +54,8 @@ func TestSegmenterUnicode(t *testing.T) {
 // TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2000
 
 	seg := graphemes.NewSegmenter(nil)
@@ -76,6 +80,8 @@ func TestSegmenterRoundtrip(t *testing.T) {
 }
 
 func TestSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 

--- a/iterators/filter/filter_test.go
+++ b/iterators/filter/filter_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestContains(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		input    string
 		expected bool
@@ -33,6 +35,8 @@ func TestContains(t *testing.T) {
 }
 
 func TestEntirely(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		input    string
 		expected bool

--- a/iterators/scanner_test.go
+++ b/iterators/scanner_test.go
@@ -3,19 +3,31 @@ package iterators_test
 import (
 	"bufio"
 	"bytes"
+	"crypto/rand"
 	"strings"
 	"testing"
 
+	"github.com/clipperhouse/uax29/graphemes"
 	"github.com/clipperhouse/uax29/iterators"
 	"github.com/clipperhouse/uax29/iterators/transformer"
+	"github.com/clipperhouse/uax29/phrases"
+	"github.com/clipperhouse/uax29/sentences"
 	"github.com/clipperhouse/uax29/words"
 )
 
+var splits = []bufio.SplitFunc{words.SplitFunc, sentences.SplitFunc, graphemes.SplitFunc, phrases.SplitFunc}
+
 func TestScannerSameAsBufio(t *testing.T) {
-	splits := []bufio.SplitFunc{words.SplitFunc, bufio.ScanWords}
+	t.Parallel()
+
+	text := make([]byte, 50000)
+
 	for _, split := range splits {
 		for i := 0; i < 100; i++ {
-			text := getRandomBytes()
+			_, err := rand.Read(text)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			r1 := bytes.NewReader(text)
 			sc1 := iterators.NewScanner(r1, split)
@@ -33,6 +45,8 @@ func TestScannerSameAsBufio(t *testing.T) {
 }
 
 func TestScannerFilterIsApplied(t *testing.T) {
+	t.Parallel()
+
 	text := "Hello, 世界, how are you? Nice dog aha! 👍🐶"
 
 	{
@@ -55,6 +69,8 @@ func TestScannerFilterIsApplied(t *testing.T) {
 }
 
 func TestScannerTransformIsApplied(t *testing.T) {
+	t.Parallel()
+
 	text := "Hello, 世界, I am enjoying cups of Açaí in Örebro."
 	r := strings.NewReader(text)
 	sc := iterators.NewScanner(r, bufio.ScanWords)

--- a/iterators/segmenter_test.go
+++ b/iterators/segmenter_test.go
@@ -9,27 +9,23 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/clipperhouse/uax29/graphemes"
 	"github.com/clipperhouse/uax29/iterators"
 	"github.com/clipperhouse/uax29/iterators/filter"
 	"github.com/clipperhouse/uax29/iterators/transformer"
-	"github.com/clipperhouse/uax29/phrases"
-	"github.com/clipperhouse/uax29/sentences"
 	"github.com/clipperhouse/uax29/words"
 )
 
-func getRandomBytes() []byte {
-	b := make([]byte, 50000)
-	rand.Read(b)
-
-	return b
-}
-
 func TestSegmenterSameAsScanner(t *testing.T) {
-	splits := []bufio.SplitFunc{words.SplitFunc, sentences.SplitFunc, graphemes.SplitFunc, phrases.SplitFunc}
+	t.Parallel()
+
+	text := make([]byte, 50000)
+
 	for _, split := range splits {
 		for i := 0; i < 100; i++ {
-			text := getRandomBytes()
+			_, err := rand.Read(text)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			seg := iterators.NewSegmenter(split)
 			seg.SetText(text)
@@ -58,13 +54,19 @@ func TestSegmenterSameAsScanner(t *testing.T) {
 }
 
 func TestSegmenterSameAsAll(t *testing.T) {
-	splits := []bufio.SplitFunc{words.SplitFunc, bufio.ScanWords}
+	t.Parallel()
+
+	text := make([]byte, 50000)
+
 	for _, split := range splits {
 		for i := 0; i < 100; i++ {
-			text := getRandomBytes()
+			_, err := rand.Read(text)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			var all [][]byte
-			err := iterators.All(text, &all, split)
+			err = iterators.All(text, &all, split)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -90,6 +92,8 @@ var startsWithH = func(token []byte) bool {
 }
 
 func TestSegmenterFilterIsApplied(t *testing.T) {
+	t.Parallel()
+
 	text := "Hello, 世界, how are you? Nice dog aha! 👍🐶"
 
 	seg := iterators.NewSegmenter(bufio.ScanWords)
@@ -110,6 +114,8 @@ func TestSegmenterFilterIsApplied(t *testing.T) {
 }
 
 func TestSegmenterTransformIsApplied(t *testing.T) {
+	t.Parallel()
+
 	text := "Hello, 世界, I am enjoying cups of Açaí in Örebro."
 
 	seg := iterators.NewSegmenter(bufio.ScanWords)
@@ -131,6 +137,8 @@ func TestSegmenterTransformIsApplied(t *testing.T) {
 }
 
 func TestSegmenterStart(t *testing.T) {
+	t.Parallel()
+
 	text := []byte("Hello world")
 
 	{
@@ -176,6 +184,8 @@ func TestSegmenterStart(t *testing.T) {
 }
 
 func TestSegmenterEnd(t *testing.T) {
+	t.Parallel()
+
 	text := []byte("Hello world")
 
 	{

--- a/iterators/transformer/transform.go
+++ b/iterators/transformer/transform.go
@@ -13,12 +13,42 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
+type lower struct{}
+
+func (l lower) Transform(dst []byte, src []byte, atEOF bool) (nDst int, nSrc int, err error) {
+	c := cases.Lower(language.Und)
+	return c.Transform(dst, src, atEOF)
+}
+func (l lower) Reset() {
+	// no-op for our purposes
+}
+
+type upper struct{}
+
+func (u upper) Transform(dst []byte, src []byte, atEOF bool) (nDst int, nSrc int, err error) {
+	c := cases.Upper(language.Und)
+	return c.Transform(dst, src, atEOF)
+}
+func (l upper) Reset() {
+	// no-op for our purposes
+}
+
+type diacritics struct{}
+
+func (d diacritics) Transform(dst []byte, src []byte, atEOF bool) (nDst int, nSrc int, err error) {
+	c := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC) // https://stackoverflow.com/q/24588295
+	return c.Transform(dst, src, atEOF)
+}
+func (l diacritics) Reset() {
+	// no-op for our purposes
+}
+
 // Lower transforms text to lowercase
-var Lower transform.Transformer = cases.Lower(language.Und)
+var Lower transform.Transformer = lower{}
 
 // Upper transforms text to uppercase
-var Upper transform.Transformer = cases.Upper(language.Und)
+var Upper transform.Transformer = upper{}
 
 // Diacritics 'flattens' characters with diacritics, such as accents. For example,
 // açaí → acai. (It has the side effect of normalizing to NFC form, which should be fine.)
-var Diacritics transform.Transformer = transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC) // https://stackoverflow.com/q/24588295
+var Diacritics transform.Transformer = diacritics{}

--- a/iterators/util/util_test.go
+++ b/iterators/util/util_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestContains(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		input    string
 		expected bool
@@ -34,6 +36,8 @@ func TestContains(t *testing.T) {
 }
 
 func TestEntirely(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		input    string
 		expected bool

--- a/phrases/scanner_test.go
+++ b/phrases/scanner_test.go
@@ -14,6 +14,8 @@ import (
 // TestScannerRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestScannerRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2000
 
 	for i := 0; i < runs; i++ {
@@ -38,6 +40,8 @@ func TestScannerRoundtrip(t *testing.T) {
 }
 
 func TestInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
@@ -71,6 +75,8 @@ func TestInvalidUTF8(t *testing.T) {
 }
 
 func TestNeverZeroAtEOF(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return advance = 0 when atEOF. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 
@@ -88,6 +94,8 @@ func TestNeverZeroAtEOF(t *testing.T) {
 }
 
 func TestNeverErr(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return an error. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 

--- a/phrases/segmenter_test.go
+++ b/phrases/segmenter_test.go
@@ -16,6 +16,8 @@ import (
 // TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2000
 
 	seg := phrases.NewSegmenter(nil)
@@ -40,6 +42,8 @@ func TestSegmenterRoundtrip(t *testing.T) {
 }
 
 func TestSegmenterWordlike(t *testing.T) {
+	t.Parallel()
+
 	text := []byte("Hello, 世界. Nice dog! 👍🐶")
 	seg := phrases.NewSegmenter(text)
 	seg.Filter(filter.Entirely(unicode.Punct))
@@ -50,6 +54,8 @@ func TestSegmenterWordlike(t *testing.T) {
 }
 
 func TestSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
@@ -92,6 +98,8 @@ func segToSetTrimmed(seg *iterators.Segmenter) map[string]struct{} {
 }
 
 func TestPhraseBoundaries(t *testing.T) {
+	t.Parallel()
+
 	input := []byte("This should break here. And then here. 世界. I think, perhaps you can understand that — aside 🏆 🐶 here — “a quote”.")
 	seg := phrases.NewSegmenter(input)
 	got := segToSetTrimmed(seg)

--- a/sentences/scanner_test.go
+++ b/sentences/scanner_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestScannerUnicode(t *testing.T) {
+	t.Parallel()
+
 	// From the Unicode test suite; see the gen/ folder.
 	var passed, failed int
 	for _, test := range unicodeTests {
@@ -46,6 +48,8 @@ func TestScannerUnicode(t *testing.T) {
 // TestScannerRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestScannerRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2_000
 
 	for i := 0; i < runs; i++ {
@@ -69,6 +73,8 @@ func TestScannerRoundtrip(t *testing.T) {
 }
 
 func TestInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
@@ -107,6 +113,8 @@ func TestInvalidUTF8(t *testing.T) {
 }
 
 func TestNeverZeroAtEOF(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return advance = 0 when atEOF. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 
@@ -124,6 +132,8 @@ func TestNeverZeroAtEOF(t *testing.T) {
 }
 
 func TestNeverErr(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return an error. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 

--- a/sentences/segmenter_test.go
+++ b/sentences/segmenter_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestSegmenterUnicode(t *testing.T) {
+	t.Parallel()
+
 	// From the Unicode test suite; see the gen/ folder.
 	var passed, failed int
 	for _, test := range unicodeTests {
@@ -52,6 +54,8 @@ func TestSegmenterUnicode(t *testing.T) {
 // TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2000
 
 	seg := sentences.NewSegmenter(nil)
@@ -76,6 +80,8 @@ func TestSegmenterRoundtrip(t *testing.T) {
 }
 
 func TestSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 

--- a/words/bleve_compat_test.go
+++ b/words/bleve_compat_test.go
@@ -31,6 +31,8 @@ var none filter.Func = func(token []byte) bool {
 }
 
 func TestAdhocSegmentsWithType(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input       []byte
 		output      [][]byte

--- a/words/scanner_test.go
+++ b/words/scanner_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestScannerUnicode(t *testing.T) {
+	t.Parallel()
+
 	// From the Unicode test suite; see the gen/ folder.
 	var passed, failed int
 	for _, test := range unicodeTests {
@@ -43,6 +45,8 @@ func TestScannerUnicode(t *testing.T) {
 // TestScannerRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestScannerRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2000
 
 	for i := 0; i < runs; i++ {
@@ -67,6 +71,8 @@ func TestScannerRoundtrip(t *testing.T) {
 }
 
 func TestInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
@@ -100,6 +106,8 @@ func TestInvalidUTF8(t *testing.T) {
 }
 
 func TestNeverZeroAtEOF(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return advance = 0 when atEOF. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 
@@ -117,6 +125,8 @@ func TestNeverZeroAtEOF(t *testing.T) {
 }
 
 func TestNeverErr(t *testing.T) {
+	t.Parallel()
+
 	// SplitFunc should never return an error. This test is redundant
 	// with the roundtrip test above, but nice to call out this invariant.
 

--- a/words/segmenter_test.go
+++ b/words/segmenter_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestSegmenterUnicode(t *testing.T) {
+	t.Parallel()
+
 	// From the Unicode test suite; see the gen/ folder.
 	var passed, failed int
 	for _, test := range unicodeTests {
@@ -55,6 +57,8 @@ func TestSegmenterUnicode(t *testing.T) {
 // TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
 // De facto, it also tests that we don't get infinite loops, or ever return an error.
 func TestSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
 	const runs = 2000
 
 	seg := words.NewSegmenter(nil)
@@ -79,6 +83,8 @@ func TestSegmenterRoundtrip(t *testing.T) {
 }
 
 func TestSegmenterWordlike(t *testing.T) {
+	t.Parallel()
+
 	text := []byte("Hello, 世界. Nice dog! 👍🐶")
 	seg := words.NewSegmenter(text)
 	seg.Filter(filter.Entirely(unicode.Punct))
@@ -89,6 +95,8 @@ func TestSegmenterWordlike(t *testing.T) {
 }
 
 func TestSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
 	// For background, see testdata/UTF-8-test.txt, or:
 	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 


### PR DESCRIPTION
Revealed when running tests with `t.Parallel()`. I didn’t realize that the `Transformer`s are stateful, and was using a single static instance of each. Replaced with a stateless wrapper.

Make all the tests parallel — not so much for performance as a better race test.