### PR TITLE
String segmenter

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.20', '1.21', '1.22', '1.23', '1.24']
+        go-version: ['1.20', '1.21', '1.22', '1.23', '1.24', '1.25']
     steps:
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/clipperhouse/uax29
 
-go 1.21
+go 1.20
 
 require golang.org/x/text v0.16.0
-
-require github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/clipperhouse/uax29
 
-go 1.19
+go 1.21
 
 require golang.org/x/text v0.16.0
+
+require github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
-github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=

--- a/graphemes/scanner_test.go
+++ b/graphemes/scanner_test.go
@@ -159,7 +159,7 @@ func getRandomBytes() []byte {
 
 	len := mathrand.Intn(max-min) + min
 	b := make([]byte, len)
-	rand.Read(b)
+	_, _ = rand.Read(b)
 
 	return b
 }

--- a/graphemes/segmenter.go
+++ b/graphemes/segmenter.go
@@ -4,19 +4,20 @@ import (
 	"github.com/clipperhouse/uax29/iterators"
 )
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
-// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+// NewSegmenter returns a Segmenter, which is an iterator over the source text.
+// Iterate while Next() is true, and access the grapheme via Bytes().
 func NewSegmenter(data []byte) *iterators.Segmenter {
 	seg := iterators.NewSegmenter(SplitFunc)
 	seg.SetText(data)
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// SegmentAll will iterate through all graphemes and collect them into a [][]byte.
 // This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// graphemes. Use Segmenter for more bounded memory usage.
 func SegmentAll(data []byte) [][]byte {
 	// Optimization: guesstimate that the average grapheme is 1 bytes,
 	// allocate a large enough array to avoid resizing

--- a/graphemes/string_segmenter.go
+++ b/graphemes/string_segmenter.go
@@ -2,21 +2,23 @@ package graphemes
 
 import "github.com/clipperhouse/uax29/iterators"
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
-// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+// NewStringSegmenter returns a StringSegmenter, which is an iterator over the
+// source text. Iterate while Next() is true, and access the grapheme via
+// Text().
 func NewStringSegmenter(data string) *iterators.StringSegmenter {
 	seg := iterators.NewStringSegmenter(SplitFunc)
 	seg.SetText(data)
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
-// This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// SegmentAllString will iterate through all graphemes and collect them into a
+// []string. This is a convenience method -- if you will be allocating such a
+// slice anyway, this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// graphemes. Use StringSegmenter for more bounded memory usage.
 func SegmentAllString(data string) []string {
-	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// Optimization: guesstimate that the average grapheme is 1 byte,
 	// allocate a large enough array to avoid resizing
 	result := make([]string, 0, len(data))
 	seg := NewStringSegmenter(data)

--- a/graphemes/string_segmenter.go
+++ b/graphemes/string_segmenter.go
@@ -1,0 +1,28 @@
+package graphemes
+
+import "github.com/clipperhouse/uax29/iterators"
+
+// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
+// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+func NewStringSegmenter(data string) *iterators.StringSegmenter {
+	seg := iterators.NewStringSegmenter(SplitFunc)
+	seg.SetText(data)
+	return seg
+}
+
+// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// This is a convenience method -- if you will be allocating such a slice anyway,
+// this will save you some code. The downside is that this allocation is
+// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
+// memory usage.
+func StringSegmentAll(data string) []string {
+	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// allocate a large enough array to avoid resizing
+	result := make([]string, 0, len(data))
+	seg := NewStringSegmenter(data)
+	for seg.Next() {
+		result = append(result, seg.Text())
+	}
+
+	return result
+}

--- a/graphemes/string_segmenter.go
+++ b/graphemes/string_segmenter.go
@@ -15,7 +15,7 @@ func NewStringSegmenter(data string) *iterators.StringSegmenter {
 // this will save you some code. The downside is that this allocation is
 // unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
 // memory usage.
-func StringSegmentAll(data string) []string {
+func SegmentAllString(data string) []string {
 	// Optimization: guesstimate that the average grapheme is 1 bytes,
 	// allocate a large enough array to avoid resizing
 	result := make([]string, 0, len(data))

--- a/graphemes/string_segmenter_test.go
+++ b/graphemes/string_segmenter_test.go
@@ -45,7 +45,7 @@ func TestStringSegmenterUnicode(t *testing.T) {
 		}
 
 		// Test SegmentAll while we're here
-		all := graphemes.StringSegmentAll(string(test.input))
+		all := graphemes.SegmentAllString(string(test.input))
 		if !reflect.DeepEqual(all, segmented) {
 			t.Error("calling SegmentAll should be identical to iterating Segmenter")
 		}
@@ -154,10 +154,10 @@ func BenchmarkStringSegmentAll(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = graphemes.StringSegmentAll(s)
+		_ = graphemes.SegmentAllString(s)
 	}
 
-	c := len(graphemes.StringSegmentAll(s))
+	c := len(graphemes.SegmentAllString(s))
 	b.ReportMetric(float64(c), "tokens")
 	b.Logf("tokens %d, len %d, avg %d", c, len(file), len(file)/c)
 }

--- a/graphemes/string_segmenter_test.go
+++ b/graphemes/string_segmenter_test.go
@@ -1,0 +1,191 @@
+package graphemes_test
+
+import (
+	"bytes"
+	"os"
+	"reflect"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/clipperhouse/uax29/graphemes"
+)
+
+func TestStringSegmenterUnicode(t *testing.T) {
+	t.Parallel()
+
+	// From the Unicode test suite; see the gen/ folder.
+	var passed, failed int
+	for _, test := range unicodeTests {
+		test := test
+
+		var segmented []string
+		segmenter := graphemes.NewStringSegmenter(string(test.input))
+		for segmenter.Next() {
+			segmented = append(segmented, segmenter.Text())
+		}
+
+		if err := segmenter.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := make([]string, len(test.expected))
+		for i, v := range test.expected {
+			expected[i] = string(v)
+		}
+
+		if !reflect.DeepEqual(segmented, expected) {
+			failed++
+			t.Errorf(`
+	for input %v
+	expected  %v
+	got       %v
+	spec      %s`, test.input, test.expected, segmented, test.comment)
+		} else {
+			passed++
+		}
+
+		// Test SegmentAll while we're here
+		all := graphemes.StringSegmentAll(string(test.input))
+		if !reflect.DeepEqual(all, segmented) {
+			t.Error("calling SegmentAll should be identical to iterating Segmenter")
+		}
+	}
+
+	if len(unicodeTests) != passed+failed {
+		t.Errorf("Incomplete %d tests: passed %d, failed %d", len(unicodeTests), passed, failed)
+	}
+}
+
+// TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
+// De facto, it also tests that we don't get infinite loops, or ever return an error.
+func TestStringSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	const runs = 2000
+
+	for i := 0; i < runs; i++ {
+		input := string(getRandomBytes())
+		seg := graphemes.NewStringSegmenter(input)
+
+		var output string
+		for seg.Next() {
+			output += seg.Text()
+		}
+
+		if err := seg.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		if output != input {
+			t.Fatal("input bytes are not the same as segmented bytes")
+		}
+	}
+}
+
+func TestStringSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// For background, see testdata/UTF-8-test.txt, or:
+	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+
+	// Btw, don't edit UTF-8-test.txt: your editor might turn it into valid UTF-8!
+
+	input, err := os.ReadFile("../testdata/UTF-8-test.txt")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if utf8.Valid(input) {
+		t.Error("input file should not be valid utf8")
+	}
+
+	sc := graphemes.NewStringSegmenter(string(input))
+
+	var output string
+	for sc.Next() {
+		output += sc.Text()
+	}
+	if err := sc.Err(); err != nil {
+		t.Error(err)
+	}
+
+	if output != string(input) {
+		t.Fatalf("input bytes are not the same as segmented bytes")
+	}
+}
+
+func BenchmarkStringSegmenter(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+	if err != nil {
+		b.Error(err)
+	}
+
+	s := string(file)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(file)))
+	seg := graphemes.NewStringSegmenter(s)
+
+	for i := 0; i < b.N; i++ {
+		seg.SetText(s)
+
+		c := 0
+		for seg.Next() {
+			c++
+		}
+
+		if err := seg.Err(); err != nil {
+			b.Error(err)
+		}
+
+		b.ReportMetric(float64(c), "tokens")
+	}
+}
+
+func BenchmarkStringSegmentAll(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+	if err != nil {
+		b.Error(err)
+	}
+
+	b.SetBytes(int64(len(file)))
+	s := string(file)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = graphemes.StringSegmentAll(s)
+	}
+
+	c := len(graphemes.StringSegmentAll(s))
+	b.ReportMetric(float64(c), "tokens")
+	b.Logf("tokens %d, len %d, avg %d", c, len(file), len(file)/c)
+}
+
+func BenchmarkStringUnicodeTests(b *testing.B) {
+	var buf bytes.Buffer
+	for _, test := range unicodeTests {
+		buf.Write(test.input)
+	}
+	file := buf.Bytes()
+	s := string(file)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(file)))
+
+	seg := graphemes.NewStringSegmenter(s)
+
+	for i := 0; i < b.N; i++ {
+		seg.SetText(s)
+
+		c := 0
+		for seg.Next() {
+			c++
+		}
+		if err := seg.Err(); err != nil {
+			b.Error(err)
+		}
+
+		b.ReportMetric(float64(c), "tokens")
+	}
+}

--- a/iterators/iter.go
+++ b/iterators/iter.go
@@ -19,7 +19,9 @@ func (t Token) Value() []byte {
 func (seg *Segmenter) Iter() iter.Seq[Token] {
 	return func(yield func(Token) bool) {
 		for seg.Next() {
-			yield(Token{seg.Bytes()})
+			if !yield(Token{seg.Bytes()}) {
+				return
+			}
 		}
 	}
 }
@@ -28,7 +30,9 @@ func (seg *Segmenter) Iter() iter.Seq[Token] {
 func (sc *Scanner) Iter() iter.Seq2[Token, error] {
 	return func(yield func(Token, error) bool) {
 		for sc.Scan() {
-			yield(Token{sc.Bytes()}, sc.Err()) // err should be nil here but yield anyway
+			if !yield(Token{sc.Bytes()}, sc.Err()) { // err should be nil here but yield anyway
+				return
+			}
 		}
 		if sc.Err() != nil {
 			yield(Token{sc.Bytes()}, sc.Err()) // bytes should be irrelevant here but yield anyway

--- a/iterators/iter.go
+++ b/iterators/iter.go
@@ -7,19 +7,24 @@ import (
 	"iter"
 )
 
-type Token struct {
-	value []byte
+// stringish is a type constraint that allows []byte, string, or named types backed by those
+type stringish interface {
+	~[]byte | ~string
 }
 
-func (t Token) Value() []byte {
+type Token[T stringish] struct {
+	value T
+}
+
+func (t Token[T]) Value() T {
 	return t.value
 }
 
 // Iter is an iterator that yields the all of the tokens in the segmenter, for use with range
-func (seg *Segmenter) Iter() iter.Seq[Token] {
-	return func(yield func(Token) bool) {
+func (seg *Segmenter) Iter() iter.Seq[Token[[]byte]] {
+	return func(yield func(Token[[]byte]) bool) {
 		for seg.Next() {
-			if !yield(Token{seg.Bytes()}) {
+			if !yield(Token[[]byte]{seg.Bytes()}) {
 				return
 			}
 		}
@@ -27,15 +32,26 @@ func (seg *Segmenter) Iter() iter.Seq[Token] {
 }
 
 // Iter is an iterator that yields the all of the tokens in the scanner, for use with range
-func (sc *Scanner) Iter() iter.Seq2[Token, error] {
-	return func(yield func(Token, error) bool) {
+func (sc *Scanner) Iter() iter.Seq2[Token[[]byte], error] {
+	return func(yield func(Token[[]byte], error) bool) {
 		for sc.Scan() {
-			if !yield(Token{sc.Bytes()}, sc.Err()) { // err should be nil here but yield anyway
+			if !yield(Token[[]byte]{sc.Bytes()}, sc.Err()) { // err should be nil here but yield anyway
 				return
 			}
 		}
 		if sc.Err() != nil {
-			yield(Token{sc.Bytes()}, sc.Err()) // bytes should be irrelevant here but yield anyway
+			yield(Token[[]byte]{sc.Bytes()}, sc.Err()) // bytes should be irrelevant here but yield anyway
+		}
+	}
+}
+
+// Iter is an iterator that yields the all of the tokens in the segmenter, for use with range
+func (seg *StringSegmenter) Iter() iter.Seq[Token[string]] {
+	return func(yield func(Token[string]) bool) {
+		for seg.Next() {
+			if !yield(Token[string]{seg.Text()}) {
+				return
+			}
 		}
 	}
 }

--- a/iterators/iter_test.go
+++ b/iterators/iter_test.go
@@ -45,6 +45,41 @@ func TestIterMatchesSegmenter(t *testing.T) {
 	}
 }
 
+func TestIterMatchesStringSegmenter(t *testing.T) {
+	t.Parallel()
+
+	file, err := os.ReadFile("../testdata/sample.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := string(file)
+
+	for _, splitFunc := range splitFuncs {
+		seg1 := iterators.NewStringSegmenter(splitFunc)
+		seg1.SetText(s)
+		var expected []string
+		for seg1.Next() {
+			expected = append(expected, seg1.Text())
+		}
+
+		seg2 := iterators.NewStringSegmenter(splitFunc)
+		seg2.SetText(s)
+		var got []string
+		for token := range seg2.Iter() {
+			got = append(got, token.Value())
+		}
+
+		if len(got) == 0 || len(expected) != len(got) {
+			t.Fatal("iter and segmenter returned different lengths")
+		}
+
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatal("iter and segmenter returned different results")
+		}
+	}
+}
+
 func TestIterMatchesScanner(t *testing.T) {
 	t.Parallel()
 

--- a/iterators/segmenter.go
+++ b/iterators/segmenter.go
@@ -107,10 +107,12 @@ func (seg *Segmenter) Next() bool {
 		}
 
 		if seg.transformer != nil {
-			seg.token, _, seg.err = transform.Bytes(seg.transformer, seg.token)
-			if seg.err != nil {
+			transformed, _, err := transform.Bytes(seg.transformer, seg.token)
+			if err != nil {
+				seg.err = err
 				return false
 			}
+			seg.token = transformed
 		}
 
 		if seg.filter != nil && !seg.filter(seg.token) {

--- a/iterators/segmenter_test.go
+++ b/iterators/segmenter_test.go
@@ -124,10 +124,7 @@ func TestSegmenterTransformIsApplied(t *testing.T) {
 	var tokens [][]byte
 	for seg.Next() {
 		tokens = append(tokens, seg.Bytes())
-		t.Log(seg.Text())
 	}
-
-	t.Log(tokens)
 
 	got := tokens[7]
 	expected := []byte("acai")

--- a/iterators/segmenter_test.go
+++ b/iterators/segmenter_test.go
@@ -124,14 +124,15 @@ func TestSegmenterTransformIsApplied(t *testing.T) {
 	var tokens [][]byte
 	for seg.Next() {
 		tokens = append(tokens, seg.Bytes())
+		t.Log(seg.Text())
 	}
 
-	{
-		got := tokens[7]
-		expected := []byte("acai")
-		if !bytes.Equal(expected, got) {
-			t.Fatalf("transforms of lower case or diacritics were not applied, expected %q, got %q", expected, got)
-		}
+	t.Log(tokens)
+
+	got := tokens[7]
+	expected := []byte("acai")
+	if !bytes.Equal(expected, got) {
+		t.Fatalf("transforms of lower case or diacritics were not applied, expected %q, got %q", expected, got)
 	}
 }
 

--- a/iterators/string_segmenter.go
+++ b/iterators/string_segmenter.go
@@ -23,10 +23,9 @@ type StringSegmenter struct {
 }
 
 // NewStringSegmenter creates a new StringSegmenter for the given string and SplitFunc.
-func NewStringSegmenter(s string, split bufio.SplitFunc) *StringSegmenter {
+func NewStringSegmenter(split bufio.SplitFunc) *StringSegmenter {
 	return &StringSegmenter{
 		split: split,
-		data:  s,
 	}
 }
 

--- a/iterators/string_segmenter.go
+++ b/iterators/string_segmenter.go
@@ -1,0 +1,107 @@
+package iterators
+
+import (
+	"bufio"
+	"unsafe"
+)
+
+// StringSegmenter reuses the existing SplitFunc logic while achieving zero-copy behavior.
+// It works by converting only the portion of the string needed for boundary detection
+// to []byte, then extracting the result as a string slice.
+type StringSegmenter struct {
+	split bufio.SplitFunc
+	data  string
+	pos   int
+	start int
+	token string
+	err   error
+}
+
+// NewStringSegmenter creates a new StringSegmenter for the given string and SplitFunc.
+func NewStringSegmenter(s string, split bufio.SplitFunc) *StringSegmenter {
+	return &StringSegmenter{
+		split: split,
+		data:  s,
+	}
+}
+
+// SetText sets the text for the segmenter to operate on, and resets all state.
+func (seg *StringSegmenter) SetText(s string) {
+	seg.data = s
+	seg.pos = 0
+	seg.start = 0
+	seg.token = ""
+	seg.err = nil
+}
+
+// Split sets the SplitFunc for the StringSegmenter.
+func (seg *StringSegmenter) Split(split bufio.SplitFunc) {
+	seg.split = split
+}
+
+// Next advances the segmenter to the next token. It returns false when there
+// are no remaining tokens or an error occurred.
+func (seg *StringSegmenter) Next() bool {
+	if seg.pos >= len(seg.data) {
+		return false
+	}
+
+	seg.start = seg.pos
+
+	// Convert only the remaining portion to []byte for SplitFunc using unsafe
+	// This avoids the allocation that []byte(string) would cause
+	remaining := seg.data[seg.pos:]
+	remainingBytes := stringToBytes(remaining)
+
+	advance, _, err := seg.split(remainingBytes, true)
+	if err != nil {
+		seg.err = err
+		return false
+	}
+
+	if advance <= 0 {
+		return false
+	}
+
+	seg.pos += advance
+
+	// Extract the token as a string slice of the original string
+	// This is zero-copy since we're just slicing the original string
+	seg.token = seg.data[seg.start:seg.pos]
+
+	return true
+}
+
+// stringToBytes converts a string to []byte without allocation using unsafe.
+// This is safe as long as the []byte is not modified and doesn't escape.
+func stringToBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
+// Text returns the current token as a string.
+func (seg *StringSegmenter) Text() string {
+	return seg.token
+}
+
+// Start returns the byte position of the current token in the original string.
+func (seg *StringSegmenter) Start() int {
+	return seg.start
+}
+
+// End returns the byte position after the current token in the original string.
+func (seg *StringSegmenter) End() int {
+	return seg.start + len(seg.token)
+}
+
+// Err returns any error that occurred during iteration.
+func (seg *StringSegmenter) Err() error {
+	return seg.err
+}
+
+// Reset resets the segmenter to the beginning of the string.
+func (seg *StringSegmenter) Reset() {
+	seg.pos = 0
+	seg.start = 0
+	seg.token = ""
+	seg.err = nil
+}

--- a/iterators/string_segmenter_test.go
+++ b/iterators/string_segmenter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/clipperhouse/uax29/graphemes"
 	"github.com/clipperhouse/uax29/iterators"
+	"github.com/clipperhouse/uax29/iterators/filter"
 	"github.com/clipperhouse/uax29/iterators/transformer"
 	"github.com/clipperhouse/uax29/phrases"
 	"github.com/clipperhouse/uax29/sentences"
@@ -102,16 +103,12 @@ func TestStringSegmenterTransformIsApplied(t *testing.T) {
 	text := "Hello, 世界, I am enjoying cups of Açaí in Örebro."
 
 	seg := iterators.NewStringSegmenter(text, bufio.ScanWords)
-	seg.SetText(text)
 	seg.Transform(transformer.Lower, transformer.Diacritics)
 
 	var tokens []string
 	for seg.Next() {
 		tokens = append(tokens, seg.Text())
-		t.Log(seg.Text())
 	}
-
-	t.Log(tokens)
 
 	got := tokens[7]
 	expected := "acai"
@@ -178,5 +175,26 @@ func TestStringSegmenterEnd(t *testing.T) {
 		if !reflect.DeepEqual(got, expected) {
 			t.Fatalf("end failed for bufio.ScanWords, expected %v, got %v", expected, got)
 		}
+	}
+}
+
+func TestStringSegmenterFilterIsApplied(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello, 世界, I am enjoying cups of Açaí in Örebro."
+
+	seg := iterators.NewStringSegmenter(text, words.SplitFunc)
+	seg.Filter(filter.AlphaNumeric)
+
+	var tokens []string
+	for seg.Next() {
+		tokens = append(tokens, seg.Text())
+	}
+
+	// Should only contain tokens with letters or numbers
+	// "Hello", "世", "界", "I", "am", "enjoying", "cups", "of", "Açaí", "in", "Örebro"
+	expected := []string{"Hello", "世", "界", "I", "am", "enjoying", "cups", "of", "Açaí", "in", "Örebro"}
+	if !reflect.DeepEqual(tokens, expected) {
+		t.Fatalf("filter was not applied correctly, expected %v, got %v", expected, tokens)
 	}
 }

--- a/iterators/string_segmenter_test.go
+++ b/iterators/string_segmenter_test.go
@@ -40,7 +40,8 @@ func TestStringSegmenterSameAsSegmenter(t *testing.T) {
 			seg.SetText(text)
 
 			// Test with string segmenter
-			stringSeg := iterators.NewStringSegmenter(string(text), split)
+			stringSeg := iterators.NewStringSegmenter(split)
+			stringSeg.SetText(string(text))
 
 			for seg.Next() && stringSeg.Next() {
 				segBytes := seg.Bytes()
@@ -81,17 +82,18 @@ func TestStringSegmenterSameAsAll(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			stringSeg := iterators.NewStringSegmenter(string(text), split)
+			seg := iterators.NewStringSegmenter(split)
+			seg.SetText(string(text))
 
-			for i := 0; stringSeg.Next(); i++ {
+			for i := 0; seg.Next(); i++ {
 				expected := all[i]
-				got := []byte(stringSeg.Text())
+				got := []byte(seg.Text())
 				if !bytes.Equal(expected, got) {
 					t.Fatal("All and StringSegmenter should give identical results")
 				}
 			}
-			if stringSeg.Err() != nil {
-				t.Fatal(stringSeg.Err())
+			if seg.Err() != nil {
+				t.Fatal(seg.Err())
 			}
 		}
 	}
@@ -102,7 +104,8 @@ func TestStringSegmenterTransformIsApplied(t *testing.T) {
 
 	text := "Hello, 世界, I am enjoying cups of Açaí in Örebro."
 
-	seg := iterators.NewStringSegmenter(text, bufio.ScanWords)
+	seg := iterators.NewStringSegmenter(bufio.ScanWords)
+	seg.SetText(text)
 	seg.Transform(transformer.Lower, transformer.Diacritics)
 
 	var tokens []string
@@ -123,11 +126,12 @@ func TestStringSegmenterStart(t *testing.T) {
 	text := "Hello world"
 
 	{
-		stringSeg := iterators.NewStringSegmenter(text, words.SplitFunc)
+		seg := iterators.NewStringSegmenter(words.SplitFunc)
+		seg.SetText(text)
 		expected := []int{0, 5, 6}
 		var got []int
-		for stringSeg.Next() {
-			got = append(got, stringSeg.Start())
+		for seg.Next() {
+			got = append(got, seg.Start())
 		}
 		if !reflect.DeepEqual(got, expected) {
 			t.Fatalf("start failed for words.SplitFunc, expected %v, got %v", expected, got)
@@ -135,11 +139,12 @@ func TestStringSegmenterStart(t *testing.T) {
 	}
 
 	{
-		stringSeg := iterators.NewStringSegmenter(text, bufio.ScanWords)
+		seg := iterators.NewStringSegmenter(bufio.ScanWords)
+		seg.SetText(text)
 		expected := []int{0, 6}
 		var got []int
-		for stringSeg.Next() {
-			got = append(got, stringSeg.Start())
+		for seg.Next() {
+			got = append(got, seg.Start())
 		}
 		if !reflect.DeepEqual(got, expected) {
 			t.Fatalf("start failed for bufio.ScanWords, expected %v, got %v", expected, got)
@@ -153,7 +158,8 @@ func TestStringSegmenterEnd(t *testing.T) {
 	text := "Hello world"
 
 	{
-		seg := iterators.NewStringSegmenter(text, words.SplitFunc)
+		seg := iterators.NewStringSegmenter(words.SplitFunc)
+		seg.SetText(text)
 
 		expected := []int{5, 6, len(text)}
 		var got []int
@@ -166,7 +172,8 @@ func TestStringSegmenterEnd(t *testing.T) {
 	}
 
 	{
-		seg := iterators.NewStringSegmenter(text, bufio.ScanWords)
+		seg := iterators.NewStringSegmenter(bufio.ScanWords)
+		seg.SetText(text)
 		expected := []int{5, len(text)}
 		var got []int
 		for seg.Next() {
@@ -183,7 +190,8 @@ func TestStringSegmenterFilterIsApplied(t *testing.T) {
 
 	text := "Hello, 世界, I am enjoying cups of Açaí in Örebro."
 
-	seg := iterators.NewStringSegmenter(text, words.SplitFunc)
+	seg := iterators.NewStringSegmenter(words.SplitFunc)
+	seg.SetText(text)
 	seg.Filter(filter.AlphaNumeric)
 
 	var tokens []string

--- a/iterators/string_segmenter_test.go
+++ b/iterators/string_segmenter_test.go
@@ -1,0 +1,261 @@
+package iterators_test
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"reflect"
+	"testing"
+
+	"github.com/clipperhouse/uax29/graphemes"
+	"github.com/clipperhouse/uax29/iterators"
+	"github.com/clipperhouse/uax29/phrases"
+	"github.com/clipperhouse/uax29/sentences"
+	"github.com/clipperhouse/uax29/words"
+)
+
+var stringSplitFuncs = map[string]bufio.SplitFunc{
+	"words":     words.SplitFunc,
+	"sentences": sentences.SplitFunc,
+	"graphemes": graphemes.SplitFunc,
+	"phrases":   phrases.SplitFunc,
+}
+
+func TestStringSegmenterSameAsSegmenter(t *testing.T) {
+	t.Parallel()
+
+	text := make([]byte, 50000)
+
+	for _, split := range stringSplitFuncs {
+		for i := 0; i < 100; i++ {
+			_, err := rand.Read(text)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Test with []byte segmenter
+			seg := iterators.NewSegmenter(split)
+			seg.SetText(text)
+
+			// Test with string segmenter
+			stringSeg := iterators.NewStringSegmenter(string(text), split)
+
+			for seg.Next() && stringSeg.Next() {
+				segBytes := seg.Bytes()
+				stringBytes := []byte(stringSeg.Text())
+				if !bytes.Equal(segBytes, stringBytes) {
+					t.Fatalf(`
+					StringSegmenter and Segmenter should give identical results
+					Segmenter:       %q
+					StringSegmenter: %q
+					`, segBytes, stringBytes)
+				}
+			}
+			if seg.Err() != nil {
+				t.Fatal(seg.Err())
+			}
+			if stringSeg.Err() != nil {
+				t.Fatal(stringSeg.Err())
+			}
+		}
+	}
+}
+
+func TestStringSegmenterSameAsAll(t *testing.T) {
+	t.Parallel()
+
+	text := make([]byte, 50000)
+
+	for _, split := range stringSplitFuncs {
+		for i := 0; i < 100; i++ {
+			_, err := rand.Read(text)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var all [][]byte
+			err = iterators.All(text, &all, split)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			stringSeg := iterators.NewStringSegmenter(string(text), split)
+
+			for i := 0; stringSeg.Next(); i++ {
+				expected := all[i]
+				got := []byte(stringSeg.Text())
+				if !bytes.Equal(expected, got) {
+					t.Fatal("All and StringSegmenter should give identical results")
+				}
+			}
+			if stringSeg.Err() != nil {
+				t.Fatal(stringSeg.Err())
+			}
+		}
+	}
+}
+
+func TestStringSegmenterStart(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello world"
+
+	{
+		stringSeg := iterators.NewStringSegmenter(text, words.SplitFunc)
+		expected := []int{0, 5, 6}
+		var got []int
+		for stringSeg.Next() {
+			got = append(got, stringSeg.Start())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("start failed for words.SplitFunc, expected %v, got %v", expected, got)
+		}
+	}
+
+	{
+		stringSeg := iterators.NewStringSegmenter(text, bufio.ScanWords)
+		expected := []int{0, 6}
+		var got []int
+		for stringSeg.Next() {
+			got = append(got, stringSeg.Start())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("start failed for bufio.ScanWords, expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestStringSegmenterEnd(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello world"
+
+	{
+		stringSeg := iterators.NewStringSegmenter(text, words.SplitFunc)
+
+		expected := []int{5, 6, len(text)}
+		var got []int
+		for stringSeg.Next() {
+			got = append(got, stringSeg.End())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("end failed for words.SplitFunc, expected %v, got %v", expected, got)
+		}
+	}
+
+	{
+		stringSeg := iterators.NewStringSegmenter(text, bufio.ScanWords)
+		// bufio.ScanWords includes the space in the first token, so "Hello " ends at position 6
+		expected := []int{6, len(text)}
+		var got []int
+		for stringSeg.Next() {
+			got = append(got, stringSeg.End())
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Fatalf("end failed for bufio.ScanWords, expected %v, got %v", expected, got)
+		}
+	}
+}
+
+func TestStringSegmenterSetText(t *testing.T) {
+	t.Parallel()
+
+	stringSeg := iterators.NewStringSegmenter("", graphemes.SplitFunc)
+
+	// Test with first text
+	stringSeg.SetText("Hello")
+	var results1 []string
+	for stringSeg.Next() {
+		results1 = append(results1, stringSeg.Text())
+	}
+
+	// Test with second text
+	stringSeg.SetText("世界")
+	var results2 []string
+	for stringSeg.Next() {
+		results2 = append(results2, stringSeg.Text())
+	}
+
+	if len(results1) != 5 {
+		t.Errorf("expected 5 graphemes for 'Hello', got %d", len(results1))
+	}
+	if len(results2) != 2 {
+		t.Errorf("expected 2 graphemes for '世界', got %d", len(results2))
+	}
+}
+
+func TestStringSegmenterWithGraphemes(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello, 世界! 👍"
+	stringSeg := iterators.NewStringSegmenter(text, graphemes.SplitFunc)
+
+	var results []string
+	for stringSeg.Next() {
+		results = append(results, stringSeg.Text())
+	}
+
+	expected := []string{"H", "e", "l", "l", "o", ",", " ", "世", "界", "!", " ", "👍"}
+	if len(results) != len(expected) {
+		t.Fatalf("expected %d graphemes, got %d", len(expected), len(results))
+	}
+
+	for i, result := range results {
+		if result != expected[i] {
+			t.Errorf("grapheme %d: expected %q, got %q", i, expected[i], result)
+		}
+	}
+}
+
+func TestStringSegmenterWithWords(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello world 世界"
+	stringSeg := iterators.NewStringSegmenter(text, words.SplitFunc)
+
+	var results []string
+	for stringSeg.Next() {
+		results = append(results, stringSeg.Text())
+	}
+
+	// words.SplitFunc includes spaces and punctuation as separate tokens
+	expected := []string{"Hello", " ", "world", " ", "世", "界"}
+	if len(results) != len(expected) {
+		t.Fatalf("expected %d words, got %d: %v", len(expected), len(results), results)
+	}
+
+	for i, result := range results {
+		if result != expected[i] {
+			t.Errorf("word %d: expected %q, got %q", i, expected[i], result)
+		}
+	}
+}
+
+func TestStringSegmenterWithScanWords(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello world 世界"
+	stringSeg := iterators.NewStringSegmenter(text, bufio.ScanWords)
+
+	var results []string
+	for stringSeg.Next() {
+		results = append(results, stringSeg.Text())
+	}
+
+	// bufio.ScanWords skips spaces and punctuation
+	expected := []string{"Hello", "world", "世界"}
+	if len(results) != len(expected) {
+		t.Fatalf("expected %d words, got %d: %v", len(expected), len(results), results)
+	}
+
+	for i, result := range results {
+		// Trim any trailing spaces that might be included
+		trimmed := result
+		if len(trimmed) > 0 && trimmed[len(trimmed)-1] == ' ' {
+			trimmed = trimmed[:len(trimmed)-1]
+		}
+		if trimmed != expected[i] {
+			t.Errorf("word %d: expected %q, got %q (trimmed from %q)", i, expected[i], trimmed, result)
+		}
+	}
+}

--- a/phrases/segmenter.go
+++ b/phrases/segmenter.go
@@ -4,19 +4,20 @@ import (
 	"github.com/clipperhouse/uax29/iterators"
 )
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
-// Iterate while Next() is true, and access the segmented phrases via Bytes().
+// NewSegmenter returns a Segmenter, which is an iterator over the source text.
+// Iterate while Next() is true, and access the phrase via Bytes().
 func NewSegmenter(data []byte) *iterators.Segmenter {
 	seg := iterators.NewSegmenter(SplitFunc)
 	seg.SetText(data)
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// SegmentAll will iterate through all phrases and collect them into a [][]byte.
 // This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// phrases. Use Segmenter for more bounded memory usage.
 func SegmentAll(data []byte) [][]byte {
 	// Optimization: guesstimate that the average phrase is 3 bytes,
 	// allocate a large enough array to avoid resizing

--- a/phrases/string_segmenter.go
+++ b/phrases/string_segmenter.go
@@ -1,0 +1,28 @@
+package phrases
+
+import "github.com/clipperhouse/uax29/iterators"
+
+// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
+// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+func NewStringSegmenter(data string) *iterators.StringSegmenter {
+	seg := iterators.NewStringSegmenter(SplitFunc)
+	seg.SetText(data)
+	return seg
+}
+
+// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// This is a convenience method -- if you will be allocating such a slice anyway,
+// this will save you some code. The downside is that this allocation is
+// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
+// memory usage.
+func StringSegmentAll(data string) []string {
+	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// allocate a large enough array to avoid resizing
+	result := make([]string, 0, len(data))
+	seg := NewStringSegmenter(data)
+	for seg.Next() {
+		result = append(result, seg.Text())
+	}
+
+	return result
+}

--- a/phrases/string_segmenter.go
+++ b/phrases/string_segmenter.go
@@ -2,23 +2,25 @@ package phrases
 
 import "github.com/clipperhouse/uax29/iterators"
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
-// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+// NewStringSegmenter returns a StringSegmenter, which is an iterator over the
+// source text. Iterate while Next() is true, and access the phrase via
+// Text().
 func NewStringSegmenter(data string) *iterators.StringSegmenter {
 	seg := iterators.NewStringSegmenter(SplitFunc)
 	seg.SetText(data)
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
-// This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// SegmentAllString will iterate through all phrases and collect them into a
+// []string. This is a convenience method -- if you will be allocating such a
+// slice anyway, this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// phrases. Use StringSegmenter for more bounded memory usage.
 func SegmentAllString(data string) []string {
-	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// Optimization: guesstimate that the average phrase is 20 bytes,
 	// allocate a large enough array to avoid resizing
-	result := make([]string, 0, len(data))
+	result := make([]string, 0, len(data)/20)
 	seg := NewStringSegmenter(data)
 	for seg.Next() {
 		result = append(result, seg.Text())

--- a/phrases/string_segmenter.go
+++ b/phrases/string_segmenter.go
@@ -15,7 +15,7 @@ func NewStringSegmenter(data string) *iterators.StringSegmenter {
 // this will save you some code. The downside is that this allocation is
 // unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
 // memory usage.
-func StringSegmentAll(data string) []string {
+func SegmentAllString(data string) []string {
 	// Optimization: guesstimate that the average grapheme is 1 bytes,
 	// allocate a large enough array to avoid resizing
 	result := make([]string, 0, len(data))

--- a/phrases/string_segmenter_test.go
+++ b/phrases/string_segmenter_test.go
@@ -1,0 +1,184 @@
+package phrases_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/clipperhouse/uax29/iterators"
+	"github.com/clipperhouse/uax29/iterators/filter"
+	"github.com/clipperhouse/uax29/phrases"
+)
+
+// TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
+// De facto, it also tests that we don't get infinite loops, or ever return an error.
+func TestStringSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	const runs = 2000
+
+	seg := phrases.NewStringSegmenter("")
+
+	for i := 0; i < runs; i++ {
+		input := string(getRandomBytes())
+		seg.SetText(input)
+
+		var output string
+		for seg.Next() {
+			output += seg.Text()
+		}
+
+		if err := seg.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		if output != input {
+			t.Fatal("input bytes are not the same as segmented bytes")
+		}
+	}
+}
+
+func TestStringSegmenterWordlike(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello, 世界. Nice dog! 👍🐶"
+	seg := phrases.NewStringSegmenter(text)
+	seg.Filter(filter.Entirely(unicode.Punct))
+
+	for seg.Next() {
+		t.Logf("%q\n", seg.Text())
+	}
+}
+
+func TestStringSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// For background, see testdata/UTF-8-test.txt, or:
+	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+
+	// Btw, don't edit UTF-8-test.txt: your editor might turn it into valid UTF-8!
+
+	input, err := os.ReadFile("../testdata/UTF-8-test.txt")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if utf8.Valid(input) {
+		t.Error("input file should not be valid utf8")
+	}
+
+	sc := phrases.NewSegmenter(input)
+
+	var output []byte
+	for sc.Next() {
+		output = append(output, sc.Bytes()...)
+	}
+	if err := sc.Err(); err != nil {
+		t.Error(err)
+	}
+
+	if !bytes.Equal(output, input) {
+		t.Fatalf("input bytes are not the same as segmented bytes")
+	}
+}
+
+func stringSegToSetTrimmed(seg *iterators.StringSegmenter) map[string]struct{} {
+	founds := make(map[string]struct{})
+	for seg.Next() {
+		key := strings.TrimSpace(seg.Text())
+		founds[key] = exists
+	}
+	return founds
+}
+
+func TestStringPhraseBoundaries(t *testing.T) {
+	t.Parallel()
+
+	input := []byte("This should break here. And then here. 世界. I think, perhaps you can understand that — aside 🏆 🐶 here — “a quote”.")
+	seg := phrases.NewStringSegmenter(string(input))
+	got := stringSegToSetTrimmed(seg)
+	expecteds := map[string]struct{}{
+		"This should break here":          exists,
+		"And then here":                   exists,
+		"世":                               exists, // We don't have great logic for languages without spaces. Also true for words, see Notes: https://unicode.org/reports/tr29/#WB999
+		"I think":                         exists,
+		"perhaps you can understand that": exists,
+		"aside 🏆 🐶 here":                  exists,
+		"a quote":                         exists,
+	}
+
+	for phrase := range expecteds {
+		_, found := got[phrase]
+		if !found {
+			t.Fatalf("phrase %q was expected, not found", phrase)
+		}
+	}
+}
+
+func BenchmarkStringSegmenter(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+
+	if err != nil {
+		b.Error(err)
+	}
+
+	s := string(file)
+
+	len := len(file)
+	b.SetBytes(int64(len))
+	seg := phrases.NewStringSegmenter(s)
+
+	b.ResetTimer()
+	c := 0
+	start := time.Now()
+
+	for i := 0; i < b.N; i++ {
+		seg.SetText(s)
+
+		for seg.Next() {
+			c++
+		}
+
+		if err := seg.Err(); err != nil {
+			b.Error(err)
+		}
+	}
+
+	elapsed := time.Since(start)
+	n := float64(b.N)
+
+	tokensPerOp := float64(c) / n
+	nsPerOp := float64(elapsed.Nanoseconds()) / n
+
+	b.ReportMetric(1e3*tokensPerOp/nsPerOp, "MMtokens/s")
+	b.ReportMetric(tokensPerOp, "tokens/op")
+	b.ReportMetric(float64(len)/tokensPerOp, "B/token")
+}
+
+func BenchmarkStringSegmentAll(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+
+	if err != nil {
+		b.Error(err)
+	}
+
+	s := string(file)
+	b.ResetTimer()
+	b.SetBytes(int64(len(file)))
+
+	for i := 0; i < b.N; i++ {
+		phrases := phrases.StringSegmentAll(s)
+
+		c := 0
+		for range phrases {
+			c++
+		}
+
+		b.ReportMetric(float64(c), "tokens")
+	}
+}

--- a/phrases/string_segmenter_test.go
+++ b/phrases/string_segmenter_test.go
@@ -172,7 +172,7 @@ func BenchmarkStringSegmentAll(b *testing.B) {
 	b.SetBytes(int64(len(file)))
 
 	for i := 0; i < b.N; i++ {
-		phrases := phrases.StringSegmentAll(s)
+		phrases := phrases.SegmentAllString(s)
 
 		c := 0
 		for range phrases {

--- a/sentences/segmenter.go
+++ b/sentences/segmenter.go
@@ -4,7 +4,7 @@ import (
 	"github.com/clipperhouse/uax29/iterators"
 )
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
+// NewSegmenter returns a Segmenter, which is an iterator over the source text.
 // Iterate while Next() is true, and access the segmented sentences via Bytes().
 func NewSegmenter(data []byte) *iterators.Segmenter {
 	seg := iterators.NewSegmenter(SplitFunc)
@@ -12,15 +12,16 @@ func NewSegmenter(data []byte) *iterators.Segmenter {
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// SegmentAll will iterate through all sentences and collect them into a [][]byte.
 // This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// sentences. Use Segmenter for more bounded memory usage.
 func SegmentAll(data []byte) [][]byte {
-	// Optimization: guesstimate that the average sentence is 100 bytes,
+	// Optimization: guesstimate that the average sentence is 50 bytes,
 	// allocate a large enough array to avoid resizing
-	result := make([][]byte, 0, len(data)/100)
+	result := make([][]byte, 0, len(data)/50)
 
 	_ = iterators.All(data, &result, SplitFunc) // can elide the error, see tests
 	return result

--- a/sentences/string_segmenter.go
+++ b/sentences/string_segmenter.go
@@ -1,0 +1,28 @@
+package sentences
+
+import "github.com/clipperhouse/uax29/iterators"
+
+// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
+// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+func NewStringSegmenter(data string) *iterators.StringSegmenter {
+	seg := iterators.NewStringSegmenter(SplitFunc)
+	seg.SetText(data)
+	return seg
+}
+
+// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// This is a convenience method -- if you will be allocating such a slice anyway,
+// this will save you some code. The downside is that this allocation is
+// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
+// memory usage.
+func StringSegmentAll(data string) []string {
+	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// allocate a large enough array to avoid resizing
+	result := make([]string, 0, len(data))
+	seg := NewStringSegmenter(data)
+	for seg.Next() {
+		result = append(result, seg.Text())
+	}
+
+	return result
+}

--- a/sentences/string_segmenter.go
+++ b/sentences/string_segmenter.go
@@ -2,23 +2,25 @@ package sentences
 
 import "github.com/clipperhouse/uax29/iterators"
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
-// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+// NewStringSegmenter returns a StringSegmenter, which is an iterator over the
+// source text. Iterate while Next() is true, and access the sentence via
+// Text().
 func NewStringSegmenter(data string) *iterators.StringSegmenter {
 	seg := iterators.NewStringSegmenter(SplitFunc)
 	seg.SetText(data)
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
-// This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// SegmentAllString will iterate through all sentences and collect them into a
+// []string. This is a convenience method -- if you will be allocating such a
+// slice anyway, this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// sentences. Use StringSegmenter for more bounded memory usage.
 func SegmentAllString(data string) []string {
-	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// Optimization: guesstimate that the average sentence is 50 bytes,
 	// allocate a large enough array to avoid resizing
-	result := make([]string, 0, len(data))
+	result := make([]string, 0, len(data)/50)
 	seg := NewStringSegmenter(data)
 	for seg.Next() {
 		result = append(result, seg.Text())

--- a/sentences/string_segmenter.go
+++ b/sentences/string_segmenter.go
@@ -15,7 +15,7 @@ func NewStringSegmenter(data string) *iterators.StringSegmenter {
 // this will save you some code. The downside is that this allocation is
 // unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
 // memory usage.
-func StringSegmentAll(data string) []string {
+func SegmentAllString(data string) []string {
 	// Optimization: guesstimate that the average grapheme is 1 bytes,
 	// allocate a large enough array to avoid resizing
 	result := make([]string, 0, len(data))

--- a/sentences/string_segmenter_test.go
+++ b/sentences/string_segmenter_test.go
@@ -45,7 +45,7 @@ func TestStringSegmenterUnicode(t *testing.T) {
 		}
 
 		// Test SegmentAll while we're here
-		all := sentences.StringSegmentAll(string(test.input))
+		all := sentences.SegmentAllString(string(test.input))
 		if !reflect.DeepEqual(all, segmented) {
 			t.Error("calling SegmentAll should be identical to iterating Segmenter")
 		}
@@ -154,10 +154,10 @@ func BenchmarkStringSegmentAll(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = sentences.StringSegmentAll(s)
+		_ = sentences.SegmentAllString(s)
 	}
 
-	c := len(sentences.StringSegmentAll(s))
+	c := len(sentences.SegmentAllString(s))
 	b.ReportMetric(float64(c), "tokens")
 	b.Logf("tokens %d, len %d, avg %d", c, len(file), len(file)/c)
 }

--- a/sentences/string_segmenter_test.go
+++ b/sentences/string_segmenter_test.go
@@ -1,0 +1,191 @@
+package sentences_test
+
+import (
+	"bytes"
+	"os"
+	"reflect"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/clipperhouse/uax29/sentences"
+)
+
+func TestStringSegmenterUnicode(t *testing.T) {
+	t.Parallel()
+
+	// From the Unicode test suite; see the gen/ folder.
+	var passed, failed int
+	for _, test := range unicodeTests {
+		test := test
+
+		var segmented []string
+		segmenter := sentences.NewStringSegmenter(string(test.input))
+		for segmenter.Next() {
+			segmented = append(segmented, segmenter.Text())
+		}
+
+		if err := segmenter.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := make([]string, len(test.expected))
+		for i, v := range test.expected {
+			expected[i] = string(v)
+		}
+
+		if !reflect.DeepEqual(segmented, expected) {
+			failed++
+			t.Errorf(`
+	for input %v
+	expected  %v
+	got       %v
+	spec      %s`, test.input, test.expected, segmented, test.comment)
+		} else {
+			passed++
+		}
+
+		// Test SegmentAll while we're here
+		all := sentences.StringSegmentAll(string(test.input))
+		if !reflect.DeepEqual(all, segmented) {
+			t.Error("calling SegmentAll should be identical to iterating Segmenter")
+		}
+	}
+
+	if len(unicodeTests) != passed+failed {
+		t.Errorf("Incomplete %d tests: passed %d, failed %d", len(unicodeTests), passed, failed)
+	}
+}
+
+// TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
+// De facto, it also tests that we don't get infinite loops, or ever return an error.
+func TestStringSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	const runs = 2000
+
+	for i := 0; i < runs; i++ {
+		input := string(getRandomBytes())
+		seg := sentences.NewStringSegmenter(input)
+
+		var output string
+		for seg.Next() {
+			output += seg.Text()
+		}
+
+		if err := seg.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		if output != input {
+			t.Fatal("input bytes are not the same as segmented bytes")
+		}
+	}
+}
+
+func TestStringSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// For background, see testdata/UTF-8-test.txt, or:
+	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+
+	// Btw, don't edit UTF-8-test.txt: your editor might turn it into valid UTF-8!
+
+	input, err := os.ReadFile("../testdata/UTF-8-test.txt")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if utf8.Valid(input) {
+		t.Error("input file should not be valid utf8")
+	}
+
+	sc := sentences.NewStringSegmenter(string(input))
+
+	var output string
+	for sc.Next() {
+		output += sc.Text()
+	}
+	if err := sc.Err(); err != nil {
+		t.Error(err)
+	}
+
+	if output != string(input) {
+		t.Fatalf("input bytes are not the same as segmented bytes")
+	}
+}
+
+func BenchmarkStringSegmenter(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+	if err != nil {
+		b.Error(err)
+	}
+
+	s := string(file)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(file)))
+	seg := sentences.NewStringSegmenter(s)
+
+	for i := 0; i < b.N; i++ {
+		seg.SetText(s)
+
+		c := 0
+		for seg.Next() {
+			c++
+		}
+
+		if err := seg.Err(); err != nil {
+			b.Error(err)
+		}
+
+		b.ReportMetric(float64(c), "tokens")
+	}
+}
+
+func BenchmarkStringSegmentAll(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+	if err != nil {
+		b.Error(err)
+	}
+
+	b.SetBytes(int64(len(file)))
+	s := string(file)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = sentences.StringSegmentAll(s)
+	}
+
+	c := len(sentences.StringSegmentAll(s))
+	b.ReportMetric(float64(c), "tokens")
+	b.Logf("tokens %d, len %d, avg %d", c, len(file), len(file)/c)
+}
+
+func BenchmarkStringUnicodeTests(b *testing.B) {
+	var buf bytes.Buffer
+	for _, test := range unicodeTests {
+		buf.Write(test.input)
+	}
+	file := buf.Bytes()
+	s := string(file)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(file)))
+
+	seg := sentences.NewStringSegmenter(s)
+
+	for i := 0; i < b.N; i++ {
+		seg.SetText(s)
+
+		c := 0
+		for seg.Next() {
+			c++
+		}
+		if err := seg.Err(); err != nil {
+			b.Error(err)
+		}
+
+		b.ReportMetric(float64(c), "tokens")
+	}
+}

--- a/words/joiners.go
+++ b/words/joiners.go
@@ -6,6 +6,12 @@ func (seg *Segmenter) Joiners(j *Joiners) {
 	seg.Split(j.splitFunc)
 }
 
+// Joiners sets runes that should be treated like word characters, where
+// otherwise words will be split. See the [Joiners] type.
+func (seg *StringSegmenter) Joiners(j *Joiners) {
+	seg.Split(j.splitFunc)
+}
+
 // Joiners allows specification of characters (runes) which will join words (tokens)
 // rather than breaking them. For example, "@" breaks words by default,
 // but you might wish to join words into email addresses.

--- a/words/scanner_test.go
+++ b/words/scanner_test.go
@@ -182,7 +182,7 @@ func getRandomBytes() []byte {
 
 	len := mathrand.Intn(max-min) + min
 	b := make([]byte, len)
-	rand.Read(b)
+	_, _ = rand.Read(b)
 
 	return b
 }

--- a/words/segmenter.go
+++ b/words/segmenter.go
@@ -13,8 +13,8 @@ type Segmenter struct {
 	*iterators.Segmenter
 }
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
-// Iterate while Next() is true, and access the segmented words via Bytes().
+// NewSegmenter returns a Segmenter, which is an iterator over the source text.
+// Iterate while Next() is true, and access the word via Bytes().
 func NewSegmenter(data []byte) *Segmenter {
 	seg := &Segmenter{
 		iterators.NewSegmenter(SplitFunc),
@@ -23,11 +23,12 @@ func NewSegmenter(data []byte) *Segmenter {
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// SegmentAll will iterate through all words and collect them into a [][]byte.
 // This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// words. Use Segmenter for more bounded memory usage.
 func SegmentAll(data []byte) [][]byte {
 	// Optimization: guesstimate that the average word is 3 bytes,
 	// allocate a large enough array to avoid resizing

--- a/words/string_segmenter.go
+++ b/words/string_segmenter.go
@@ -22,7 +22,7 @@ func NewStringSegmenter(data string) *StringSegmenter {
 // this will save you some code. The downside is that this allocation is
 // unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
 // memory usage.
-func StringSegmentAll(data string) []string {
+func SegmentAllString(data string) []string {
 	// Optimization: guesstimate that the average grapheme is 1 bytes,
 	// allocate a large enough array to avoid resizing
 	result := make([]string, 0, len(data))

--- a/words/string_segmenter.go
+++ b/words/string_segmenter.go
@@ -2,10 +2,17 @@ package words
 
 import "github.com/clipperhouse/uax29/iterators"
 
+type StringSegmenter struct {
+	// made a words.Segmenter so we can attach the Joiners method just for words.
+	*iterators.StringSegmenter
+}
+
 // NewSegmenter retuns a Segmenter, which is an iterator over the source text.
 // Iterate while Next() is true, and access the segmented graphemes via Bytes().
-func NewStringSegmenter(data string) *iterators.StringSegmenter {
-	seg := iterators.NewStringSegmenter(SplitFunc)
+func NewStringSegmenter(data string) *StringSegmenter {
+	seg := &StringSegmenter{
+		iterators.NewStringSegmenter(SplitFunc),
+	}
 	seg.SetText(data)
 	return seg
 }

--- a/words/string_segmenter.go
+++ b/words/string_segmenter.go
@@ -7,8 +7,8 @@ type StringSegmenter struct {
 	*iterators.StringSegmenter
 }
 
-// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
-// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+// NewStringSegmenter returns a StringSegmenter, which is an iterator over the
+// source text. Iterate while Next() is true, and access the word via Text().
 func NewStringSegmenter(data string) *StringSegmenter {
 	seg := &StringSegmenter{
 		iterators.NewStringSegmenter(SplitFunc),
@@ -17,15 +17,16 @@ func NewStringSegmenter(data string) *StringSegmenter {
 	return seg
 }
 
-// SegmentAll will iterate through all tokens and collect them into a [][]byte.
-// This is a convenience method -- if you will be allocating such a slice anyway,
-// this will save you some code. The downside is that this allocation is
-// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
-// memory usage.
+// SegmentAllString will iterate through all words and collect them into a
+// []string. This is a convenience method -- if you will be allocating such a
+// slice anyway, this will save you some code.
+//
+// The downside is that this allocation is unbounded -- O(n) on the number of
+// words. Use StringSegmenter for more bounded memory usage.
 func SegmentAllString(data string) []string {
-	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// Optimization: guesstimate that the average word is 3 bytes,
 	// allocate a large enough array to avoid resizing
-	result := make([]string, 0, len(data))
+	result := make([]string, 0, len(data)/3)
 	seg := NewStringSegmenter(data)
 	for seg.Next() {
 		result = append(result, seg.Text())

--- a/words/string_segmenter.go
+++ b/words/string_segmenter.go
@@ -1,0 +1,28 @@
+package words
+
+import "github.com/clipperhouse/uax29/iterators"
+
+// NewSegmenter retuns a Segmenter, which is an iterator over the source text.
+// Iterate while Next() is true, and access the segmented graphemes via Bytes().
+func NewStringSegmenter(data string) *iterators.StringSegmenter {
+	seg := iterators.NewStringSegmenter(SplitFunc)
+	seg.SetText(data)
+	return seg
+}
+
+// SegmentAll will iterate through all tokens and collect them into a [][]byte.
+// This is a convenience method -- if you will be allocating such a slice anyway,
+// this will save you some code. The downside is that this allocation is
+// unbounded -- O(n) on the number of tokens. Use Segmenter for more bounded
+// memory usage.
+func StringSegmentAll(data string) []string {
+	// Optimization: guesstimate that the average grapheme is 1 bytes,
+	// allocate a large enough array to avoid resizing
+	result := make([]string, 0, len(data))
+	seg := NewStringSegmenter(data)
+	for seg.Next() {
+		result = append(result, seg.Text())
+	}
+
+	return result
+}

--- a/words/string_segmenter_test.go
+++ b/words/string_segmenter_test.go
@@ -1,0 +1,191 @@
+package words_test
+
+import (
+	"bytes"
+	"os"
+	"reflect"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/clipperhouse/uax29/words"
+)
+
+func TestStringSegmenterUnicode(t *testing.T) {
+	t.Parallel()
+
+	// From the Unicode test suite; see the gen/ folder.
+	var passed, failed int
+	for _, test := range unicodeTests {
+		test := test
+
+		var segmented []string
+		segmenter := words.NewStringSegmenter(string(test.input))
+		for segmenter.Next() {
+			segmented = append(segmented, segmenter.Text())
+		}
+
+		if err := segmenter.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := make([]string, len(test.expected))
+		for i, v := range test.expected {
+			expected[i] = string(v)
+		}
+
+		if !reflect.DeepEqual(segmented, expected) {
+			failed++
+			t.Errorf(`
+	for input %v
+	expected  %v
+	got       %v
+	spec      %s`, test.input, test.expected, segmented, test.comment)
+		} else {
+			passed++
+		}
+
+		// Test SegmentAll while we're here
+		all := words.StringSegmentAll(string(test.input))
+		if !reflect.DeepEqual(all, segmented) {
+			t.Error("calling SegmentAll should be identical to iterating Segmenter")
+		}
+	}
+
+	if len(unicodeTests) != passed+failed {
+		t.Errorf("Incomplete %d tests: passed %d, failed %d", len(unicodeTests), passed, failed)
+	}
+}
+
+// TestSegmenterRoundtrip tests that all input bytes are output after segmentation.
+// De facto, it also tests that we don't get infinite loops, or ever return an error.
+func TestStringSegmenterRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	const runs = 2000
+
+	for i := 0; i < runs; i++ {
+		input := string(getRandomBytes())
+		seg := words.NewStringSegmenter(input)
+
+		var output string
+		for seg.Next() {
+			output += seg.Text()
+		}
+
+		if err := seg.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		if output != input {
+			t.Fatal("input bytes are not the same as segmented bytes")
+		}
+	}
+}
+
+func TestStringSegmenterInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// For background, see testdata/UTF-8-test.txt, or:
+	// https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+
+	// Btw, don't edit UTF-8-test.txt: your editor might turn it into valid UTF-8!
+
+	input, err := os.ReadFile("../testdata/UTF-8-test.txt")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if utf8.Valid(input) {
+		t.Error("input file should not be valid utf8")
+	}
+
+	sc := words.NewStringSegmenter(string(input))
+
+	var output string
+	for sc.Next() {
+		output += sc.Text()
+	}
+	if err := sc.Err(); err != nil {
+		t.Error(err)
+	}
+
+	if output != string(input) {
+		t.Fatalf("input bytes are not the same as segmented bytes")
+	}
+}
+
+func BenchmarkStringSegmenter(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+	if err != nil {
+		b.Error(err)
+	}
+
+	s := string(file)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(file)))
+	seg := words.NewStringSegmenter(s)
+
+	for i := 0; i < b.N; i++ {
+		seg.SetText(s)
+
+		c := 0
+		for seg.Next() {
+			c++
+		}
+
+		if err := seg.Err(); err != nil {
+			b.Error(err)
+		}
+
+		b.ReportMetric(float64(c), "tokens")
+	}
+}
+
+func BenchmarkStringSegmentAll(b *testing.B) {
+	file, err := os.ReadFile("../testdata/sample.txt")
+	if err != nil {
+		b.Error(err)
+	}
+
+	b.SetBytes(int64(len(file)))
+	s := string(file)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = words.StringSegmentAll(s)
+	}
+
+	c := len(words.StringSegmentAll(s))
+	b.ReportMetric(float64(c), "tokens")
+	b.Logf("tokens %d, len %d, avg %d", c, len(file), len(file)/c)
+}
+
+func BenchmarkStringUnicodeTests(b *testing.B) {
+	var buf bytes.Buffer
+	for _, test := range unicodeTests {
+		buf.Write(test.input)
+	}
+	file := buf.Bytes()
+	s := string(file)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(file)))
+
+	seg := words.NewStringSegmenter(s)
+
+	for i := 0; i < b.N; i++ {
+		seg.SetText(s)
+
+		c := 0
+		for seg.Next() {
+			c++
+		}
+		if err := seg.Err(); err != nil {
+			b.Error(err)
+		}
+
+		b.ReportMetric(float64(c), "tokens")
+	}
+}

--- a/words/string_segmenter_test.go
+++ b/words/string_segmenter_test.go
@@ -45,7 +45,7 @@ func TestStringSegmenterUnicode(t *testing.T) {
 		}
 
 		// Test SegmentAll while we're here
-		all := words.StringSegmentAll(string(test.input))
+		all := words.SegmentAllString(string(test.input))
 		if !reflect.DeepEqual(all, segmented) {
 			t.Error("calling SegmentAll should be identical to iterating Segmenter")
 		}
@@ -183,10 +183,10 @@ func BenchmarkStringSegmentAll(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = words.StringSegmentAll(s)
+		_ = words.SegmentAllString(s)
 	}
 
-	c := len(words.StringSegmentAll(s))
+	c := len(words.SegmentAllString(s))
 	b.ReportMetric(float64(c), "tokens")
 	b.Logf("tokens %d, len %d, avg %d", c, len(file), len(file)/c)
 }

--- a/words/string_segmenter_test.go
+++ b/words/string_segmenter_test.go
@@ -82,6 +82,35 @@ func TestStringSegmenterRoundtrip(t *testing.T) {
 	}
 }
 
+func stringSegToSet(seg *words.StringSegmenter) map[string]struct{} {
+	founds := make(map[string]struct{})
+	for seg.Next() {
+		founds[seg.Text()] = struct{}{}
+	}
+	return founds
+}
+
+func TestStringSegmenterJoiners(t *testing.T) {
+	s := string(joinersInput)
+	seg1 := words.NewStringSegmenter(s)
+	founds1 := stringSegToSet(seg1)
+
+	seg2 := words.NewStringSegmenter(s)
+	seg2.Joiners(joiners)
+	founds2 := stringSegToSet(seg2)
+
+	for _, test := range joinersTests {
+		_, found1 := founds1[test.input]
+		if found1 != test.found1 {
+			t.Fatalf("For %q, expected %t for found in non-config segmenter, but got %t", test.input, test.found1, found1)
+		}
+		_, found2 := founds2[test.input]
+		if found2 != test.found2 {
+			t.Fatalf("For %q, expected %t for found in segmenter with joiners, but got %t", test.input, test.found2, found2)
+		}
+	}
+}
+
 func TestStringSegmenterInvalidUTF8(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
In Go, if one is in the domain of bytes, slicing & iterating are fast. When one is in the domain of strings, same. When moving _between_ those domains, there is ~always allocation.

This PR introduces a `StringSegmenter`, so a caller working in strings does not need to convert to bytes to use this package. The goal is that it’s ~identical to `Segmenter` as much as possible, but operates on strings, and therefore doesn’t allocate or require the caller to allocate.

I’ve chosen to use `unsafe` to get the string’s bytes, and then use the existing `SplitFunc`, to avoid redundancy. To this end, I’ve bumped to Go `1.20` as a minimum, as that version introduced some `unsafe` niceties for this very purpose.

I believe it is safe to use `unsafe` (heh), as we do not mutate the underlying bytes, thereby keeping `string`’s promise of immutability from the caller’s perspective.