### PR TITLE
Troubleshoot code functionality

### DIFF
--- a/phrases/bytes.go
+++ b/phrases/bytes.go
@@ -1,0 +1,17 @@
+package phrases
+
+import (
+	"github.com/clipperhouse/uax29/iterators"
+)
+
+// BytesIterator is an iterator for phrases. Iterate while Next() is true,
+// and access the phrase via Bytes().
+type BytesIterator = iterators.Segmenter
+
+// FromBytes returns an iterator for the phrases in the input bytes.
+// Iterate while Next() is true, and access the phrase via Bytes().
+func FromBytes(data []byte) *BytesIterator {
+	seg := iterators.NewSegmenter(SplitFunc)
+	seg.SetText(data)
+	return seg
+}


### PR DESCRIPTION
Add `phrases/bytes.go` to correctly implement a byte-based phrase iterator by aligning with the existing `iterators.Segmenter` pattern.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff901603-2492-4250-bba1-e23c6877d0fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff901603-2492-4250-bba1-e23c6877d0fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

